### PR TITLE
ci: add npm publish workflow; scope biome to hand-maintained files and enforce it

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -16,3 +16,7 @@ src/version.ts
 
 # CI + publishing are hand-maintained (Fern doesn't manage workflows here)
 .github/
+
+# Lint config is scoped to hand-maintained files (generated code is excluded);
+# Fern's default biome.json would undo that scoping.
+biome.json

--- a/.fernignore
+++ b/.fernignore
@@ -10,3 +10,9 @@ README.md
 # Hand-maintained docs / history
 LICENSE
 CHANGELOG.md
+
+# SDK version constant (bumped by hand at release time)
+src/version.ts
+
+# CI + publishing are hand-maintained (Fern doesn't manage workflows here)
+.github/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Compile
         run: pnpm build
 
+      - name: Lint (hand-maintained files)
+        run: pnpm check
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,36 @@
+name: publish-npm
+# Builds the hedra-node package from the committed SDK and publishes to npm.
+# Triggered when a GitHub Release is published. Requires the HEDRA_NPM_TOKEN secret.
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || secrets.HEDRA_NPM_TOKEN }}
+        run: npm publish --access public

--- a/biome.json
+++ b/biome.json
@@ -21,7 +21,12 @@
             "!!*.log",
             "!!**/*.log",
             "!!**/.DS_Store",
-            "!!**/Thumbs.db"
+            "!!**/Thumbs.db",
+            "!!tests/setup.ts",
+            "!!src",
+            "!!tests/unit",
+            "!!tests/mock-server",
+            "!!scripts"
         ]
     },
     "formatter": {

--- a/package.json
+++ b/package.json
@@ -1,72 +1,72 @@
 {
-  "name": "hedra-node",
-  "version": "0.3.0",
-  "private": false,
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/hedra-labs/hedra-node.git"
-  },
-  "type": "commonjs",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.mjs",
-  "types": "./dist/cjs/index.d.ts",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./dist/esm/index.d.mts",
-        "default": "./dist/esm/index.mjs"
-      },
-      "require": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
-      },
-      "default": "./dist/cjs/index.js"
+    "name": "hedra-node",
+    "version": "0.3.0",
+    "private": false,
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/hedra-labs/hedra-node.git"
     },
-    "./package.json": "./package.json"
-  },
-  "files": [
-    "dist",
-    "reference.md",
-    "README.md",
-    "LICENSE"
-  ],
-  "scripts": {
-    "format": "biome format --write --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
-    "format:check": "biome format --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
-    "lint": "biome lint --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
-    "lint:fix": "biome lint --fix --unsafe --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
-    "check": "biome check --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
-    "check:fix": "biome check --fix --unsafe --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
-    "build": "pnpm build:cjs && pnpm build:esm",
-    "build:cjs": "tsc --project ./tsconfig.cjs.json",
-    "build:esm": "tsc --project ./tsconfig.esm.json && node scripts/rename-to-esm-files.js dist/esm",
-    "test": "vitest",
-    "test:unit": "vitest --project unit",
-    "test:wire": "vitest --project wire"
-  },
-  "dependencies": {},
-  "devDependencies": {
-    "webpack": "^5.105.4",
-    "ts-loader": "^9.5.4",
-    "vitest": "^4.1.1",
-    "msw": "2.11.2",
-    "@types/node": "^20.0.0",
-    "typescript": "~5.9.3",
-    "@biomejs/biome": "2.4.10"
-  },
-  "browser": {
-    "fs": false,
-    "os": false,
-    "path": false,
-    "stream": false,
-    "crypto": false
-  },
-  "packageManager": "pnpm@10.33.0",
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "sideEffects": false,
-  "description": "The official TypeScript library for the Hedra API",
-  "license": "Apache-2.0",
-  "author": "Hedra <support@hedra.com>"
+    "type": "commonjs",
+    "main": "./dist/cjs/index.js",
+    "module": "./dist/esm/index.mjs",
+    "types": "./dist/cjs/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./dist/esm/index.d.mts",
+                "default": "./dist/esm/index.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            },
+            "default": "./dist/cjs/index.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "files": [
+        "dist",
+        "reference.md",
+        "README.md",
+        "LICENSE"
+    ],
+    "scripts": {
+        "format": "biome format --write --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
+        "format:check": "biome format --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
+        "lint": "biome lint --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
+        "lint:fix": "biome lint --fix --unsafe --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
+        "check": "biome check --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
+        "check:fix": "biome check --fix --unsafe --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
+        "build": "pnpm build:cjs && pnpm build:esm",
+        "build:cjs": "tsc --project ./tsconfig.cjs.json",
+        "build:esm": "tsc --project ./tsconfig.esm.json && node scripts/rename-to-esm-files.js dist/esm",
+        "test": "vitest",
+        "test:unit": "vitest --project unit",
+        "test:wire": "vitest --project wire"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "webpack": "^5.105.4",
+        "ts-loader": "^9.5.4",
+        "vitest": "^4.1.1",
+        "msw": "2.11.2",
+        "@types/node": "^20.0.0",
+        "typescript": "~5.9.3",
+        "@biomejs/biome": "2.4.10"
+    },
+    "browser": {
+        "fs": false,
+        "os": false,
+        "path": false,
+        "stream": false,
+        "crypto": false
+    },
+    "packageManager": "pnpm@10.33.0",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "sideEffects": false,
+    "description": "The official TypeScript library for the Hedra API",
+    "license": "Apache-2.0",
+    "author": "Hedra <support@hedra.com>"
 }

--- a/tests/wire/main.test.ts
+++ b/tests/wire/main.test.ts
@@ -76,13 +76,7 @@ describe("HedraClient", () => {
             error: null,
         };
 
-        server
-            .mockEndpoint()
-            .get("/requests/req_123")
-            .respondWith()
-            .statusCode(200)
-            .jsonBody(rawResponseBody)
-            .build();
+        server.mockEndpoint().get("/requests/req_123").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.requests.get("req_123");
         expect(response).toEqual(rawResponseBody);


### PR DESCRIPTION
- publish-npm.yml: release-triggered npm publish (mirrors hedra-python's
  publish-pypi), using the existing HEDRA_NPM_TOKEN secret
- biome: exclude fern-generated sources (src/, generated test infra, scripts/)
  so check covers the hand-maintained files, and run it in CI
- .fernignore: protect src/version.ts and .github/ from regeneration

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
