### PR TITLE
ci(publish): derive the published version from the release tag

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,10 +1,21 @@
 name: publish-npm
 # Builds the hedra-node package from the committed SDK and publishes to npm.
 # Triggered when a GitHub Release is published. Requires the HEDRA_NPM_TOKEN secret.
+#
+# The published version is derived from the release tag, NOT from package.json.
+# package.json is .fernignore'd and hand-maintained, so its version drifts from
+# what is actually being released -- before this, a release at v1.0.0 would have
+# tagged v1.0.0 and then published package.json's stale number to npm. See
+# ENG-10111.
 on:
   release:
     types: [published]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, e.g. 1.0.0 (required: a manual run has no release tag to derive it from)"
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -12,6 +23,29 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+
+      # Resolves from the release tag on a `release` run, or from the input on a
+      # manual one. Fails loudly rather than falling back to package.json, so a
+      # misconfigured run cannot quietly publish the wrong number.
+      - name: Resolve version to publish
+        id: resolve
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          raw="${RELEASE_TAG:-${INPUT_VERSION:-}}"
+          if [ -z "$raw" ]; then
+            echo "::error::No version to publish. A release run takes it from the release tag; a manual run requires the 'version' input."
+            exit 1
+          fi
+          version="${raw#v}"
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Resolved version '$version' (from '$raw') is not valid semver; refusing to publish."
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Publishing version $version (from '$raw')."
 
       - name: Set up node
         uses: actions/setup-node@v6
@@ -23,6 +57,29 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # No commit: the working copy is discarded when the job ends. --allow-same-version
+      # keeps this a no-op rather than an error when package.json already matches the tag.
+      - name: Write the resolved version into package.json
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: npm version --no-git-tag-version --allow-same-version "$VERSION"
+
+      # src/version.ts is .fernignore'd, so it is hand-maintained and will drift from the
+      # released version unless someone bumps it. This is the only thing that surfaces that
+      # drift. Warn rather than fail on purpose: it is currently 0.3.0, so a hard failure
+      # would block the very first tag-derived release instead of reporting the problem.
+      - name: Check the runtime SDK_VERSION matches
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          sdk_version="$(grep -oE 'SDK_VERSION *= *"[^"]*"' src/version.ts | grep -oE '"[^"]*"' | tr -d '"')"
+          if [ "$sdk_version" != "$VERSION" ]; then
+            echo "::warning::src/version.ts reports SDK_VERSION=$sdk_version but publishing $VERSION. Bump src/version.ts to $VERSION (it is .fernignore'd, so it is hand-maintained today)."
+          else
+            echo "SDK_VERSION matches the published version ($VERSION)."
+          fi
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,6 +20,16 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Manual approval gate. `release: published` fires this workflow with no human
+    # in the loop -- including when fern-config's release-sdks.yml cuts the Release
+    # remotely -- so this is the only thing standing between a published Release and
+    # a live npm publish. The job queues until a required reviewer approves it.
+    #
+    # The protection lives in the environment's settings, NOT here: GitHub creates a
+    # referenced environment on first use if it is missing, WITHOUT protection rules,
+    # so a missing or unconfigured `npm-publish` environment silently publishes
+    # rather than failing. If you rename this, configure the new environment first.
+    environment: npm-publish
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6


### PR DESCRIPTION
`publish-npm.yml` runs `pnpm build` then `npm publish`, both of which take the version from `package.json` — currently `0.3.0`. It never looks at the release tag, and
`package.json` is `.fernignore`'d, so `fern generate --version 1.0.0` in fern-config cannot write it either.

Net effect today: a release at 1.0.0 would tag `v1.0.0`, cut the GitHub Release, and then publish **0.3.0** to npm. npm would accept it, because the latest published
version is 0.1.2. The reset would look like it succeeded while shipping the wrong number.

## What this does

**Derives the published version from the release tag.** A new `Resolve version to publish` step reads `github.event.release.tag_name`, strips a leading `v`, and
validates the result is semver before anything else runs. `npm version --no-git-tag-version --allow-same-version` then writes it into `package.json` ahead of
build/test/publish. No commit — the working copy is discarded when the job ends.

Using `github.event.release.tag_name` rather than `GITHUB_REF_NAME` is deliberate: it is correct for both `v1.0.0` and `1.0.0` tag formats and is not affected by how
the workflow was triggered.

**Guards the `workflow_dispatch` path**, which has no release tag to derive from. It now takes a required `version` input, and the resolve step fails with an explicit
message if it somehow arrives empty. The step never falls back to `package.json` — a misconfigured run fails loudly instead of quietly publishing a stale number,
which is the whole failure mode being fixed.

**Reports drift in the hand-maintained `src/version.ts`.** A non-fatal step compares its `SDK_VERSION` against the resolved version and emits a `::warning::` if they
disagree. It is currently `0.3.0`, so this *will* fire on the first tag-derived release — that is the intent. It warns rather than fails deliberately: a hard failure
would block the release instead of reporting the problem. Bumping `src/version.ts` is a manual release step until the follow-up below lands.

## Scope: this was split

This PR originally also removed `src/version.ts` from `.fernignore`, per ENG-10111 change 2. That half is **not safe to land yet** and now lives in its own PR,
[#24](https://github.com/hedra-labs/hedra-node/pull/24), blocked on fern-config#19. Short version: fern-config's only generate path runs `fern generate --group <g>`
with **no** `--version`, so Fern would write its own auto-computed `sdkVersion` (`0.1.3` today, and not monotonic) over the current `0.3.0` — which is exactly what
commit `8d4b8e0` did on 2026-07-08 before `6b1a566` added the ignore entry back 17 minutes later. Full evidence is in #24.

Nothing in this PR depends on that. It is safe to land on its own.

## Deliberately not doing

Un-ignoring `package.json` (docs/sdk-versioning.md §3.3b). Handing it to Fern would import exactly the failure mode #22 fixed, and would break `--frozen-lockfile`
now that the lockfile is hand-owned. See ENG-10108 §4.

## Verification

`publish-npm.yml` only runs on a release, so it cannot be exercised by CI on this PR. I verified the parts that can be checked without cutting a release:

- **YAML parses**, 10 steps, triggers `[release, workflow_dispatch]`.
- **The resolve step's shell body was extracted and run against 11 cases**, all passing: `v1.0.0` and bare `1.0.0` → `1.0.0`; prerelease `v1.0.0-rc.1` preserved;
  manual input with and without the `v`; release tag correctly taking precedence over an input; and the four rejection paths — empty, non-semver (`release-candidate`),
  partial (`v1.0`), and a shell-injection-shaped tag, each failing with its intended message rather than executing anything.
- **`--allow-same-version` is load-bearing**, not decoration: without it `npm version` exits with `npm error Version not changed` when `package.json` already matches
  the tag, which would fail the publish on any re-run. Verified both ways.
- **`npm version` touches only the version field** — diffed the full `package.json` before and after with the version key removed; byte-identical.
- **The `SDK_VERSION` grep returns `0.3.0`** against the real `src/version.ts`.
- The lockfile records no root package version, so writing `package.json`'s version cannot invalidate `--frozen-lockfile` regardless of step order.

Part of ENG-10111.
