### PR TITLE
chore(fern): let Fern own src/version.ts

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -11,25 +11,26 @@ README.md
 LICENSE
 CHANGELOG.md
 
-# NOTE: src/version.ts is deliberately NOT listed. Fern generates it from
-# `fern generate --version X`, so the runtime constant and the version
-# publish-npm.yml derives from the release tag come from the same number
-# instead of being hand-bumped.
+# NOTE: src/version.ts is deliberately NOT listed, so Fern owns the runtime
+# constant instead of it being hand-bumped.
 #
-# This ONLY holds if EVERY generate that targets this repo passes --version.
-# fern-config#19 added `release-sdks.yml`, which does (group ts-release, mode
-# release). But `generate-sdks.yml` -- the automatic one, fired by any push to
-# fern/** -- still runs `fern generate --group ts` with NO version, and Fern
-# then writes its own auto-computed sdkVersion: 0.1.3 today, and not monotonic
-# (it has already gone 0.2.0 -> 0.1.3). So a release would stamp the right
-# number and the next spec sync would walk it back.
+# Every generate targeting this repo stamps it -- `--version` selects WHICH
+# number, never whether one is written: GithubOutputMode.version is a required
+# field, and a config omitting it is rejected with PARSE_ERROR, so Fern Cloud
+# just fills it with its own auto-computed value when the flag is absent. That
+# value is not monotonic (it has gone 0.2.0 -> 0.1.3), and it is what rewrote
+# SDK_VERSION 0.3.0 -> 0.1.3 in commit 8d4b8e0 on 2026-07-08 -- after which
+# 6b1a566 added this entry back 17 minutes later.
 #
-# That is not hypothetical: commit 8d4b8e0 (2026-07-08 13:57 PDT) rewrote
-# SDK_VERSION 0.3.0 -> 0.1.3 exactly this way, and 6b1a566 added the ignore
-# entry back at 14:14 PDT -- 17 minutes later.
+# Safe to omit now because fern-config#37 makes generate-sdks.yml pass
+# --version pinned to this repo's package.json version, so a routine
+# regeneration stamps whatever package.json already says.
 #
-# Do not re-remove this entry until `generate-sdks.yml` also passes --version,
-# pinned to the last released version so routine regenerations hold it steady.
+# THAT MAKES package.json THE SOURCE OF TRUTH. Bump it on main when cutting a
+# release: release-sdks.yml stamps this file with the released version, but
+# package.json is .fernignore'd and publish-npm.yml only rewrites it inside the
+# job's throwaway checkout -- so if main's package.json stays behind, the next
+# regeneration pins to the stale number and walks SDK_VERSION back.
 
 # Dependency lockfile. Fern regenerates it on every SDK regeneration, which
 # silently reverts anything committed here — it already ate a merged fast-uri

--- a/.fernignore
+++ b/.fernignore
@@ -16,12 +16,20 @@ CHANGELOG.md
 # publish-npm.yml derives from the release tag come from the same number
 # instead of being hand-bumped.
 #
-# This ONLY holds once fern-config runs a release-mode generate that passes an
-# explicit --version. Until then `generate-sdks.yml` runs `fern generate --group
-# <g>` with no version, and Fern writes its own auto-computed sdkVersion --
-# which is 0.1.3 today and is not monotonic. That is what commit 8d4b8e0 did on
-# 2026-07-08: it rewrote SDK_VERSION 0.3.0 -> 0.1.3, and 6b1a566 added the
-# ignore entry back 17 minutes later. Do not re-remove it before fern-config#19.
+# This ONLY holds if EVERY generate that targets this repo passes --version.
+# fern-config#19 added `release-sdks.yml`, which does (group ts-release, mode
+# release). But `generate-sdks.yml` -- the automatic one, fired by any push to
+# fern/** -- still runs `fern generate --group ts` with NO version, and Fern
+# then writes its own auto-computed sdkVersion: 0.1.3 today, and not monotonic
+# (it has already gone 0.2.0 -> 0.1.3). So a release would stamp the right
+# number and the next spec sync would walk it back.
+#
+# That is not hypothetical: commit 8d4b8e0 (2026-07-08 13:57 PDT) rewrote
+# SDK_VERSION 0.3.0 -> 0.1.3 exactly this way, and 6b1a566 added the ignore
+# entry back at 14:14 PDT -- 17 minutes later.
+#
+# Do not re-remove this entry until `generate-sdks.yml` also passes --version,
+# pinned to the last released version so routine regenerations hold it steady.
 
 # Dependency lockfile. Fern regenerates it on every SDK regeneration, which
 # silently reverts anything committed here — it already ate a merged fast-uri

--- a/.fernignore
+++ b/.fernignore
@@ -11,8 +11,17 @@ README.md
 LICENSE
 CHANGELOG.md
 
-# SDK version constant (bumped by hand at release time)
-src/version.ts
+# NOTE: src/version.ts is deliberately NOT listed. Fern generates it from
+# `fern generate --version X`, so the runtime constant and the version
+# publish-npm.yml derives from the release tag come from the same number
+# instead of being hand-bumped.
+#
+# This ONLY holds once fern-config runs a release-mode generate that passes an
+# explicit --version. Until then `generate-sdks.yml` runs `fern generate --group
+# <g>` with no version, and Fern writes its own auto-computed sdkVersion --
+# which is 0.1.3 today and is not monotonic. That is what commit 8d4b8e0 did on
+# 2026-07-08: it rewrote SDK_VERSION 0.3.0 -> 0.1.3, and 6b1a566 added the
+# ignore entry back 17 minutes later. Do not re-remove it before fern-config#19.
 
 # Dependency lockfile. Fern regenerates it on every SDK regeneration, which
 # silently reverts anything committed here — it already ate a merged fast-uri


### PR DESCRIPTION
Removes `src/version.ts` from `.fernignore` so Fern owns the SDK's runtime version constant.

`src/version.ts` is a single generated line — `export const SDK_VERSION = "0.3.0";` — with nothing hand-written to protect. Ignoring it meant the constant was bumped by
hand at release time, which is exactly the kind of step that gets skipped: `main` has shipped `0.3.0` since the v3 retarget while npm's latest is `0.1.2`. Un-ignored,
Fern stamps it, and it tracks the number the package actually ships.

## Why this is safe

Fern stamps this file on **every** generate that targets this repo. `--version` selects *which* number is written, never *whether* one is — `GithubOutputMode.version`
is a required field of the generator config, and a config omitting it is rejected with `PARSE_ERROR` before generation starts. So passing no `--version` does not mean
"leave it alone"; it means Fern Cloud fills the field with its own auto-computed value. That value is not monotonic — it has gone `0.2.0` → `0.1.3`.

Both generate paths now pass an explicit version:

| Path | Group | Runs | Version source |
|---|---|---|---|
| Routine regeneration | `ts` (`mode: pull-request`) | automatically, on any push to `fern/**` | this repo's `package.json` |
| Release | `ts-release` (`mode: release`) | manually, via `release-sdks.yml` | `compute_version.py`, or a forced version |

The routine pin comes from fern-config [#37](https://github.com/hedra-labs/fern-config/pull/37). It pins to each SDK repo's own **manifest**, not to its latest release
tag — every current tag predates the Fern migration (`v0.1.2` here, from 2024-11-02), so a tag-based pin would have stamped `0.1.2` over the committed `0.3.0`.

`package.json` and `src/version.ts` are both `0.3.0` on `main` today, so the first regeneration after this merges is a no-op on this file.

## The release-time invariant

**Bump `package.json` on `main` when you cut a release.**

#37's guarantee covers regeneration, not releases. `release-sdks.yml` stamps `src/version.ts` with the released version and commits it — so published artifacts are
correct. But `package.json` is `.fernignore`d, so Fern cannot write it, and since #23 `publish-npm.yml` rewrites it only inside the job's throwaway checkout. Nothing
updates `main`'s copy.

So releasing 1.0.0 without bumping `package.json` leaves it at `0.3.0`, and the next spec sync pins there and walks `SDK_VERSION` back from `1.0.0`. Released artifacts
stay correct either way — the drift is confined to `main` between releases — but the hand-edit moved from `src/version.ts` to `package.json` rather than disappearing.

Arguably the better home: one file instead of two, it is the pin source for all three SDK repos, and `publish-npm.yml`'s `SDK_VERSION` check reports it when it goes
stale. The `.fernignore` comment records this inline so the entry is not re-added by someone who only reads the ticket.

## Not doing

Un-ignoring `package.json` (docs/sdk-versioning.md §3.3b). Handing it to Fern would import the failure mode #22 fixed, and would break `--frozen-lockfile` now that the
lockfile is hand-owned. See ENG-10108 §4.

## Diff

`.fernignore` only. Removes the `src/version.ts` stanza and replaces it with a comment recording why it is deliberately absent. The `pnpm-lock.yaml` guard from #22 is
untouched — verified present after the change.

Part of ENG-10111. Unblocked by ENG-10130.
