### PR TITLE
docs(readme): fix the usage example to match the shipped SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,32 @@ import { HedraClient } from "hedra-node";
 
 const client = new HedraClient({ apiKey: "YOUR_API_KEY" });
 
-const submitted = await client.queue.submit("kling-o3-pro", {
+const submitted = await client.jobs.submitKlingO3({
     input: {
         prompt: "a fox sprinting across fresh snow",
         aspect_ratio: "16:9",
+        duration_ms: 5000,
+        quality: "standard",
     },
 });
 
-// Poll until terminal, then fetch the result envelope (outputs, metrics)
-const status = await client.requests.getStatus(submitted.request_id);
-const result = await client.requests.get(submitted.request_id);
+// Poll until the job reaches a terminal state, then fetch the result envelope.
+let status = await client.jobs.getStatus(submitted.job_id);
+while (status.status === "IN_QUEUE" || status.status === "IN_PROGRESS") {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    status = await client.jobs.getStatus(submitted.job_id);
+}
+
+const result = await client.jobs.get(submitted.job_id);
+console.log(result.outputs?.[0]?.url);
 ```
+
+Every model has its own submit method — `submitKlingO3`, `submitVeo3`, `submitNanoBanana`
+and so on — each taking the `input` that model actually accepts, checked at compile time.
+The [reference](./reference.md) lists all of them.
+
+Instead of polling you can consume the job's server-sent event stream with
+`client.jobs.stream(job_id)`.
 
 The client authenticates with `Authorization: Bearer <api key>`; an API key is the
 `<key_id>:<secret>` credential from the Hedra console. When `apiKey` is not passed,
@@ -83,20 +98,20 @@ following namespace:
 ```typescript
 import { Hedra } from "hedra-node";
 
-const request: Hedra.SubmitRequest = {
+const request: Hedra.SubmitBodyKlingO3 = {
     ...
 };
 ```
 
 ## Pagination
 
-`client.requests.list(...)` returns a `Page` that can be iterated asynchronously; it
+`client.jobs.list(...)` returns a `Page` that can be iterated asynchronously; it
 fetches cursor pages lazily as you iterate:
 
 ```typescript
-const page = await client.requests.list({ limit: 50 });
-for await (const request of page) {
-    console.log(request.request_id, request.status);
+const page = await client.jobs.list({ limit: 50 });
+for await (const job of page) {
+    console.log(job.job_id, job.status);
 }
 ```
 
@@ -109,7 +124,7 @@ will be thrown.
 import { HedraError } from "hedra-node";
 
 try {
-    await client.queue.submit(...);
+    await client.jobs.submitKlingO3(...);
 } catch (err) {
     if (err instanceof HedraError) {
         console.log(err.statusCode);
@@ -180,7 +195,7 @@ const client = new HedraClient({
     }
 });
 
-const response = await client.queue.submit(..., {
+const response = await client.jobs.submitKlingO3(..., {
     headers: {
         'X-Custom-Header': 'custom value'
     }
@@ -192,7 +207,7 @@ const response = await client.queue.submit(..., {
 If you would like to send additional query string parameters as part of the request, use the `queryParams` request option.
 
 ```typescript
-const response = await client.queue.submit(..., {
+const response = await client.jobs.submitKlingO3(..., {
     queryParams: {
         'customQueryParamKey': 'custom query param value'
     }
@@ -222,7 +237,7 @@ Which status codes are retried depends on the `retryStatusCodes` generator confi
 Use the `maxRetries` request option to configure this behavior.
 
 ```typescript
-const response = await client.queue.submit(..., {
+const response = await client.jobs.submitKlingO3(..., {
     maxRetries: 0 // override maxRetries at the request level
 });
 ```
@@ -232,7 +247,7 @@ const response = await client.queue.submit(..., {
 The SDK defaults to a 60 second timeout. Use the `timeoutInSeconds` option to configure this behavior.
 
 ```typescript
-const response = await client.queue.submit(..., {
+const response = await client.jobs.submitKlingO3(..., {
     timeoutInSeconds: 30 // override timeout to 30s
 });
 ```
@@ -243,7 +258,7 @@ The SDK allows users to abort requests at any point by passing in an abort signa
 
 ```typescript
 const controller = new AbortController();
-const response = await client.queue.submit(..., {
+const response = await client.jobs.submitKlingO3(..., {
     abortSignal: controller.signal
 });
 controller.abort(); // aborts the request
@@ -255,7 +270,7 @@ The SDK provides access to raw response data, including headers, through the `.w
 The `.withRawResponse()` method returns a promise that results to an object with a `data` and a `rawResponse` property.
 
 ```typescript
-const { data, rawResponse } = await client.queue.submit(...).withRawResponse();
+const { data, rawResponse } = await client.jobs.submitKlingO3(...).withRawResponse();
 
 console.log(data);
 console.log(rawResponse.headers['X-My-Header']);
@@ -330,8 +345,20 @@ The SDK provides a low-level `fetch` method for making custom HTTP requests whil
 benefiting from SDK-level configuration like authentication, retries, timeouts, and logging.
 This is useful for calling API endpoints not yet supported in the SDK.
 
+Construct the client with an explicit `environment` (or `baseUrl`) when you use it. Unlike
+the resource clients, `client.fetch` does not fall back to the default production URL, so on
+a default-constructed client a relative path reaches `fetch()` unresolved and throws
+`TypeError: Failed to parse URL`.
+
 ```typescript
-const response = await client.fetch("/v1/custom/endpoint", {
+import { HedraClient, HedraEnvironment } from "hedra-node";
+
+const client = new HedraClient({
+    apiKey: "YOUR_API_KEY",
+    environment: HedraEnvironment.Production,
+});
+
+const response = await client.fetch("/some/unsupported/endpoint", {
     method: "GET",
 }, {
     timeoutInSeconds: 30,
@@ -343,6 +370,11 @@ const response = await client.fetch("/v1/custom/endpoint", {
 
 const data = await response.json();
 ```
+
+Prefer a relative path against a configured `environment`, as above — it is the one form
+that both resolves and carries the `Authorization` header on every generator version.
+Credentials are not guaranteed to be attached to an absolute URL that points somewhere
+other than your configured base.
 
 ### Runtime Compatibility
 


### PR DESCRIPTION
The README's headline Usage example — the first thing anyone copies — did not compile against the SDK it ships with. The `service_queue` / `service_requests` removal reached the SDK without the README following, so every identifier in that first code block was wrong.

## What was broken

```typescript
const submitted = await client.queue.submit("kling-o3-pro", { input: { prompt: "…", aspect_ratio: "16:9" } });
const status = await client.requests.getStatus(submitted.request_id);
const result = await client.requests.get(submitted.request_id);
```

Five separate faults in eight lines:

| | was | reality |
|---|---|---|
| resource | `client.queue` | does not exist — `Client.ts` exposes `jobs, models, keys, tokens, files, billing, webhooks, logDrains` |
| resource | `client.requests` | does not exist — same list |
| field | `submitted.request_id` | `SubmitResponse` carries `job_id` |
| model id | `kling-o3-pro` | **404s** on `GET /v3/models`; the real id is `kling-o3` |
| input | `{prompt, aspect_ratio}` | `kling-o3` also requires `duration_ms` and `quality` — this would have 422'd even with the resource name fixed |

The model id and the incomplete input are new findings; the issue only suspected them.

## The sweep was wider than the headline

The same staleness ran through **eleven** code blocks, not the one:

- **Pagination** — `client.requests.list(...)`, `request.request_id` → `client.jobs.list(...)`, `job.job_id`
- **Request and Response Types** — `Hedra.SubmitRequest`, a type with no referent anywhere in `src/` → `Hedra.SubmitBodyKlingO3`
- **Exception Handling** and all six **Advanced** snippets — `client.queue.submit(...)` ×7 → `client.jobs.submitKlingO3(...)`

## Why the per-model submit

A templated `client.jobs.submit(model, { input })` is coming with the next SDK regeneration, and the obvious move was to write the example against that and land it on the regeneration PR so the two ship together. That was tried, and the regeneration PR (#21) was closed unmerged and superseded by #25 before it landed — taking the README fix with it.

So this targets `main` and uses `submitKlingO3`, which exists here today. The README is then correct at every point in time and owes nothing to the bot cycle. It also buys something the templated call cannot: `submitKlingO3` takes a typed `InputKlingO3`, where the templated `submit` takes `Record<string, unknown>` and defers everything to a server-side 422. `tsc` rejects the original input with *"missing duration_ms, quality"* — **the bug this PR fixes could not have shipped on this route.** Promoting the templated submit to the headline once it lands is a two-line follow-up.

## Custom Fetch

Its example was broken at every generator version:

```typescript
await client.fetch("/v1/custom/endpoint", { method: "GET" });  // TypeError: Failed to parse URL
```

`client.fetch` is the one place that does not fall back to `HedraEnvironment.Production` — every resource client does. On a default-constructed client the relative path reaches `fetch()` unresolved and throws. The example now constructs the client with an explicit `environment`, the only form that both resolves and stays authenticated.

I measured all four configurations against a local capture server, at this SDK's generator (3.73.4) and at 3.87.2:

| client | path | 3.73.4 (here) | 3.87.2 (next regen) |
|---|---|---|---|
| default | relative | **throws** | **throws** |
| default | absolute | 200, auth present | 200, auth **missing** |
| `environment` set | relative | 200, auth present | 200, auth present |

The absolute-URL row diverges: 3.87.2 adds a `targetsBaseUrl` guard that withholds credentials when no base URL is configured. The wording committed here is accurate on both, so it survives the bump.

The section keeps its existing framing — with no templated submit in this SDK, `client.fetch` genuinely is how you reach an unsupported endpoint. Demoting it in favour of `client.jobs.submit` belongs with the regeneration that introduces that method; asserting it now would reintroduce exactly the class of bug this PR fixes.

## Verification

- Extracted every ` ```typescript ` block (18 total; 11 use the `...` placeholder idiom and cannot compile by construction) and typechecked the 7 self-contained ones with `tsc --strict` — clean. Covers Usage, Custom base URL, Pagination, File Uploads, Custom Fetch.
- **Negative controls**, so the check demonstrably has teeth: a bogus method name, a dropped required field, and the README's original input shape are each rejected by `tsc`.
- The example's `input` validates against the live `GET /v3/models/kling-o3` schema (`jsonschema`); `duration_ms: 5000` is in the live enum — the generated docstring's `duration_ms: 1` is a Fern placeholder that would be rejected.
- Every identifier checked against this commit rather than assumed: `submitKlingO3`, `get`, `getStatus`, `list`, `stream`, `SubmitResponse.job_id`, `JobSummary.job_id`, `JobStatus` values, `OutputItem.url`, and `HedraEnvironment` being exported from the package root.
- `biome format:check` and `lint` clean; **495 unit tests pass**.

## Not touched

Two pre-existing defects, both predating this issue: the npm badge is `img.shields.io/npm/v/` with no package name so it renders broken, and the File Uploads metadata snippets reference `Uploadable.WithMetadata` / `createReadStream` without importing either. Happy to fold them in if wanted.

`README.md` is `.fernignore`d, so this survives regeneration — though ENG-10121 is the systemic fix for why it silently went stale in the first place.

Closes ENG-10120
