### PR TITLE
docs(readme): fix the npm badge and the File Uploads imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hedra TypeScript Library
 
 [![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Hedra%2FTypeScript)
-[![npm shield](https://img.shields.io/npm/v/)](https://www.npmjs.com/package/)
+[![npm shield](https://img.shields.io/npm/v/hedra-node)](https://www.npmjs.com/package/hedra-node)
 
 The Hedra TypeScript library provides convenient access to the Hedra APIs from TypeScript.
 
@@ -140,9 +140,8 @@ try {
 You can upload files using the client:
 
 ```typescript
-import { createReadStream } from "fs";
-import { HedraClient } from "hedra-node";
 import * as fs from "fs";
+import { HedraClient } from "hedra-node";
 
 const client = new HedraClient({ apiKey: "YOUR_API_KEY" });
 await client.files.upload({
@@ -157,6 +156,9 @@ The client accepts a variety of types for file upload parameters:
 
 You can configure metadata when uploading a file:
 ```typescript
+import { createReadStream } from "fs";
+import { Uploadable } from "hedra-node";
+
 const file: Uploadable.WithMetadata = {
     data: createReadStream("path/to/file"),
     filename: "my-file",       // optional
@@ -167,7 +169,9 @@ const file: Uploadable.WithMetadata = {
 
 Alternatively, you can upload a file directly from a file path:
 ```typescript
-const file : Uploadable.FromPath = {
+import { Uploadable } from "hedra-node";
+
+const file: Uploadable.FromPath = {
     path: "path/to/file",
     filename: "my-file",        // optional
     contentType: "audio/mpeg",  // optional


### PR DESCRIPTION
Two defects in `README.md` that predate #26 and were left out of it deliberately — that PR was scoped to the stale usage example, and these were found while verifying it. Neither touches the SDK.

## The npm badge had no package name

```markdown
[![npm shield](https://img.shields.io/npm/v/)](https://www.npmjs.com/package/)
```

Both URLs were truncated, so the shield rendered broken and the link pointed at npm's package index rather than at this package. `hedra-node` is published (2 versions, latest `0.1.2`), and `img.shields.io/npm/v/hedra-node` returns `200` — the badge just never had the name filled in.

## The File Uploads metadata snippets did not compile

Both snippets under **File Uploads → Metadata** referenced `Uploadable.WithMetadata` / `Uploadable.FromPath` and `createReadStream` without importing any of them. Copied as shown, `tsc` rejects them:

```
error TS2503: Cannot find namespace 'Uploadable'.
error TS2304: Cannot find name 'createReadStream'.
```

`Uploadable` is exported from the package root, so a plain named import is all that was missing — the chain is `src/index.ts` → `src/exports.ts` → `src/core/exports.ts` → `src/core/file/exports.ts`, where it is re-exported as `export type { Uploadable }`. That type-only re-export still carries the namespace's nested members, so `Uploadable.WithMetadata` and `Uploadable.FromPath` both resolve through it — verified rather than assumed.

Two smaller things in the same section, both fixed here:

- the first upload snippet imported `createReadStream` and never used it — it calls `fs.createReadStream` from the `import * as fs` on the next line
- the `FromPath` snippet had a stray space in `const file : Uploadable.FromPath`

## Verification

Every ` ```typescript ` block in the README was extracted and typechecked with `tsc --strict` against this commit's own build — the same harness used on #26. 7 of the 18 blocks are self-contained; the other 11 use the `...` placeholder idiom and cannot compile by construction.

**All 7 now pass. Blocks 7 and 8 are the two that failed before this change** — on #26 they were the only remaining failures and were reported as pre-existing rather than silently fixed.

`biome format:check` and `lint` clean; 495 unit tests pass.

## Note

`README.md` is `.fernignore`d, so this survives SDK regeneration. ENG-10121 tracks whether that exemption is the right long-term answer — a hand-maintained README is exactly how the usage example in #26 went stale without anyone noticing.
