### PR TITLE
chore(version): bump package.json and src/version.ts to 1.0.0

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -75,10 +75,12 @@ jobs:
           VERSION: ${{ steps.resolve.outputs.version }}
         run: npm version --no-git-tag-version --allow-same-version "$VERSION"
 
-      # src/version.ts is .fernignore'd, so it is hand-maintained and will drift from the
-      # released version unless someone bumps it. This is the only thing that surfaces that
-      # drift. Warn rather than fail on purpose: it is currently 0.3.0, so a hard failure
-      # would block the very first tag-derived release instead of reporting the problem.
+      # src/version.ts is stamped by Fern, not hand-maintained: it is deliberately NOT
+      # .fernignore'd, and generate-sdks.yml pins --version to this repo's package.json
+      # (fern-config#37). So it tracks main's package.json, not the tag being released,
+      # and drifts whenever the two disagree. This is the only thing that surfaces that.
+      # Warn rather than fail on purpose: turning this into a hard failure is a separate
+      # decision, deliberately not taken alongside the 1.0.0 bump (ENG-10134).
       - name: Check the runtime SDK_VERSION matches
         env:
           VERSION: ${{ steps.resolve.outputs.version }}
@@ -86,7 +88,7 @@ jobs:
           set -euo pipefail
           sdk_version="$(grep -oE 'SDK_VERSION *= *"[^"]*"' src/version.ts | grep -oE '"[^"]*"' | tr -d '"')"
           if [ "$sdk_version" != "$VERSION" ]; then
-            echo "::warning::src/version.ts reports SDK_VERSION=$sdk_version but publishing $VERSION. Bump src/version.ts to $VERSION (it is .fernignore'd, so it is hand-maintained today)."
+            echo "::warning::src/version.ts reports SDK_VERSION=$sdk_version but publishing $VERSION. Bump package.json on main to $VERSION so the next regeneration stamps it, or set src/version.ts directly."
           else
             echo "SDK_VERSION matches the published version ($VERSION)."
           fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hedra-node",
-    "version": "0.3.0",
+    "version": "1.0.0",
     "private": false,
     "repository": {
         "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = "0.3.0";
+export const SDK_VERSION = "1.0.0";


### PR DESCRIPTION
`package.json` `0.3.0` → `1.0.0`, and `src/version.ts` `SDK_VERSION` to match. Also refreshes a comment in `publish-npm.yml` that had gone stale — no behaviour change there.

## Why this lands *before* the 1.0.0 reset release

fern-config's `release-sdks.yml` cuts the reset with `force_version=1.0.0`, and it has not been dispatched yet. It needs to find `main` already reading `1.0.0`, because a routine regeneration in the meantime would otherwise stamp `SDK_VERSION = "0.3.0"` straight over the number we are about to publish.

The pin is live. fern-config's `generate-sdks.yml` (fern-config#37) resolves `--version` for the `ts` group by fetching this repo's `package.json` and reading `.version` with `jq` — and it fetches with no `?ref=`, so it reads whatever `main` says. Every push to `fern/**` regenerates at that number.

## Why `package.json` leads

This repo's own `.fernignore` already spells out the hazard. Verbatim:

> THAT MAKES package.json THE SOURCE OF TRUTH. Bump it on main when cutting a release: release-sdks.yml stamps this file with the released version, but package.json is .fernignore'd and publish-npm.yml only rewrites it inside the job's throwaway checkout -- so if main's package.json stays behind, the next regeneration pins to the stale number and walks SDK_VERSION back.

Landing this ahead of the release is safe for exactly the same reason it is load-bearing: `package.json` is `.fernignore`'d, and `publish-npm.yml` rewrites it from the release tag inside the job's throwaway checkout (`npm version --no-git-tag-version`), so the committed number never reaches npm. Its only real consumer is the pin.

## Why `src/version.ts` is hand-set too, when Fern owns it

It is deliberately *not* `.fernignore`'d — Fern stamps it from `--version`. Setting it by hand costs nothing and keeps `main` self-consistent immediately: once `package.json` reads `1.0.0`, the next regeneration writes exactly the same value, so this is a no-op diff rather than a fight with the generator. Left at `0.3.0`, `main` would claim two different versions until something regenerates.

## The `publish-npm.yml` comment

The mismatch-check comment justified warning-rather-than-failing with *"it is currently 0.3.0, so a hard failure would block the very first tag-derived release"* — stale as of this bump. It also still described `src/version.ts` as `.fernignore`'d and hand-maintained, which stopped being true in #24. Both are corrected, and the warning string now names the actual fix (bump `package.json` so the next regeneration stamps it).

**The check still warns — it is not flipped to a hard failure.** That is a separate decision, deliberately not bundled here.

## Out of scope

- `CHANGELOG.md` — the `1.0.0` entry belongs to the release, not to this bump.
- `.fernignore:22` mentions `0.3.0` inside a historical narrative about commit `8d4b8e0`. Correct as written, left alone.
- `pnpm-lock.yaml` is hand-owned (ENG-10111). The root importer carries no version, so it is untouched — verified after the install rather than assumed.

## Verification

All green locally on this branch, off `origin/main` `d03b8cb`:

- `pnpm install --frozen-lockfile` — clean; `git diff -- pnpm-lock.yaml` empty afterwards
- `pnpm build` — cjs + esm both compile, and the run reports `hedra-node@1.0.0`
- `pnpm test` — 32 files, 1337 tests passed
- `pnpm check` — biome, 17 files, no fixes (CI gates on this too)
- `publish-npm.yml` re-parsed as valid YAML after the comment edit

Closes ENG-10134
