### PR TITLE
chore(fern): un-ignore package.json so regeneration stamps the version

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,9 +1,6 @@
 # Files Fern must NOT overwrite when it regenerates this SDK (via PR from the
 # hedra-labs/fern-config repo). See https://buildwithfern.com/learn/sdks/capabilities/customize-files
 
-# npm package name (hedra-node) + metadata (author/license/description)
-package.json
-
 # README install/imports use the hedra-node package name
 README.md
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge until [ENG-10144](https://linear.app/hedra/issue/ENG-10144/fern-config-make-the-generated-manifests-carry-what-the-hand-owned) lands in hedra-labs/fern-config.** Merged early, the next regeneration drops `description`, `author`, and `sideEffects: false` from `package.json` — ENG-10144 moves those three into the generator's `packageJson` custom config so the generated manifest keeps carrying them.

## What

One-line `.fernignore` edit: remove the `package.json` entry so Fern's regeneration PRs may write the manifest. Nothing else changes. The retired entry carried this justification:

```
# npm package name (hedra-node) + metadata (author/license/description)
package.json
```

Why it no longer holds:

- **npm package name** — set by the generator config in fern-config; the 2026-08-09 local preview (fern-config harness run 20260809-163226) shows the generated manifest keeps `"name": "hedra-node"`.
- **author / description** (plus `sideEffects: false`) — move into the generator's `packageJson` custom config in ENG-10144; that is the merge blocker above.
- **license** — already `Apache-2.0` in the shipped manifest, and the generated one carries it too; no change either way.

## Why

Second half of native-manifest-as-source-and-target for node (first half: ENG-10130 / fern-config#37, which makes `generate-sdks.yml` pin `--version` from this very file). With `package.json` ignored, the version Fern stamps lands in `src/version.ts`,
`BaseClient.ts` headers, and `.fern/metadata.json` — but never in the manifest itself, the one file the pin is read from. Un-ignoring closes the loop so those four can never disagree again.

Bonus the shipped SDK is missing because the file is ignored: the generated manifest adds eight per-resource subpath exports (`hedra-node/jobs`, `/models`, `/keys`, `/tokens`, `/files`, `/billing`, `/webhooks`, `/logDrains`). Today's exports map has only `.` and `./package.json`. Scripts, dependencies, devDependencies: unchanged in the preview.

## Noted while here (not changed)

The `src/version.ts` NOTE block in `.fernignore` (47b5173) still says "package.json is .fernignore'd" in its release-time-invariant paragraph. The invariant itself — bump `package.json` on main when cutting a release — stays true after this flip; only that clause goes stale. Left untouched per the ticket's "no other `.fernignore` changes"; flagged on ENG-10145.

## Verification

Structurally blocked until ENG-10144 merges. Afterwards, per the ticket: from fern-config, run `python scripts/e2e_regeneration_test.py --keep` and confirm the bot PR's `package.json` diff has (a) the version unchanged from the shipped one, (b) `description`/`author`/`sideEffects` intact, (c) the subpath exports present. Or simply inspect the next routine regeneration PR.

Closes ENG-10145.
