### PR TITLE
chore(fern): exclude machine-owned version files from Replay

### DIFF
--- a/.fern/replay.yml
+++ b/.fern/replay.yml
@@ -1,0 +1,22 @@
+# Hand-owned Fern Replay config (.fernignore'd — the CLI reads it, never
+# rewrites it). `exclude:` entries are minimatch globs against repo-relative
+# paths.
+#
+# Verified semantics (fern-api@5.57.0, the CLI version fern-config pins;
+# identical in 5.65.5): exclude suppresses patch APPLICATION, not detection.
+# The applicator skips a patch before any apply attempt when any of its files
+# matches any pattern, so an excluded patch can never conflict or go
+# "unresolved" ("Action required" in regeneration PRs). Detection still records
+# the patch in replay.lock's ledger; it just stays inert there.
+#
+# Whole-patch semantics: a patch is skipped ENTIRELY if ANY of its files
+# matches — keep version bumps in dedicated commits so a mixed commit doesn't
+# drag real customizations into the skip.
+
+# Machine-owned version files (ENG-10148): package.json is the version's
+# source of truth (generate-sdks.yml pins --version to it) and src/version.ts
+# is stamped by every generation. Hand-bumps to them are release mechanics,
+# not customizations to replay.
+exclude:
+  - package.json
+  - src/version.ts


### PR DESCRIPTION
## Why

Fern Replay's `current_generation` anchor in `.fern/replay.lock` still points at `7f66075` (2026-08-05). Every generation scans all main commits since that anchor for "customizations to preserve", and that range now contains the deliberate version-bump commit #30 (ENG-10134). Verified 2026-08-09: routine regenerations that stamp identical content drop the detected patches as no-ops (bot PR #34's lock diff only advances the anchor), but any generation that **moves** the version flags both files — bot PR #35 carried "Action required: 2 files with unresolved customization conflicts" for `package.json` and `src/version.ts`, both citing #30. Left alone, this fires on the first real release bump after 1.0.0.

Since ENG-10145 / fern-config#43, both files are machine-owned end to end: `package.json` is the version's source and target (generate-sdks.yml pins `--version` to it) and `src/version.ts` is stamped by every generation. Hand-bumps to them are release mechanics, not customizations to replay.

## What

Creates `.fern/replay.yml` (hand-owned; already listed in `.fernignore`; never existed in this repo before) with:

```yaml
exclude:
  - package.json
  - src/version.ts
```

## Verified exclude semantics

The ticket asked to verify, not assume, that `exclude` suppresses patch *detection*. Verified against the replay implementation in the `fern-api@5.57.0` npm bundle — the CLI version pinned by fern-config's `fern.config.json`, i.e. what actually runs generation — and cross-checked identical in 5.65.5:

- **`exclude` suppresses application, not detection.** `detectNewPatches` → `detectPatchesInRange` / `materializeCommitPatch` never consult it; detection filters only on `.fernignore` patterns, sensitive-file extensions, and already-tracked commits/content-hashes. The exclude list is read in exactly three places: the applicator's `isExcluded()`, the fernignore-migration writer (`movePatternsToReplayYml`), and status reporting.
- **Application-time suppression is sufficient to retire this conflict class.** In `applyPatches`, `isExcluded(patch)` skips the patch before any apply attempt (`status: "skipped"`). A skipped patch can never reach `status: "conflict"` and so is never marked `unresolved` — which is precisely what produces the "Action required: files with unresolved customization conflicts" banner.
- **Residual behavior:** a version-*moving* generation will still *detect* the bump commit as a patch and persist an inert entry in `replay.lock`'s `patches:` ledger (skipped at every subsequent apply, so harmless noise). Identical-content regenerations drop it as a no-op before that, as observed on #34.
- **Whole-patch semantics:** `isExcluded` is `patch.files.some(f => exclude.some(p => minimatch(f, p)))` — if *any* file of a patch matches *any* pattern, the *entire* patch is skipped, including its non-excluded files. Version bumps must stay in dedicated commits (they do: #30 and release bumps touch only these two files). This is documented in the file's comments.
- Patterns are minimatch globs against repo-relative paths, so bare `package.json` matches only the root manifest.
- **Independently corroborated** by the hedra-python sibling (ENG-10135, hedra-labs/hedra-python#45): same reading of the 5.57.0 implementation (cross-checked there against 5.92.0, here against 5.65.5), plus an end-to-end scratch-clone reproduction — an installed unresolved ledger patch plus a version-stamp move produced conflict markers without the exclude and zero markers with it.

## Anchor note

Merging any subsequent routine regeneration PR advances `current_generation` past #30, which retires the existing conflict permanently; this exclude then guards every *future* release bump. Deliberately **not** merging any regeneration PR in this change — that call stays with the repo owner.

## Verification

- `.fern/replay.yml` parses to exactly `{exclude: ["package.json", "src/version.ts"]}` — the shape `getCustomizationsConfig()` reads (plain YAML parse, no schema validation, unknown keys ignored).
- Semantics traced in the exact pinned CLI (`npm pack fern-api@5.57.0`, read `cli.cjs`): no exclude reference anywhere in the detection path; `isExcluded` only in the apply path.
- Untouched, per ticket: `.fernignore`, `package.json`, `src/version.ts`, `.fern/replay.lock`.

Closes ENG-10148
