### PR TITLE
docs(fern): fix the version NOTE now that package.json isn't ignored

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -24,9 +24,11 @@ CHANGELOG.md
 # regeneration stamps whatever package.json already says.
 #
 # THAT MAKES package.json THE SOURCE OF TRUTH. Bump it on main when cutting a
-# release: release-sdks.yml stamps this file with the released version, but
-# package.json is .fernignore'd and publish-npm.yml only rewrites it inside the
-# job's throwaway checkout -- so if main's package.json stays behind, the next
+# release: release-sdks.yml stamps this file with the released version, and
+# since #33 un-ignored package.json a regeneration stamps the manifest too --
+# but only with the number read from main's package.json itself (a round-trip
+# that can never advance it), and publish-npm.yml only rewrites it inside the
+# job's throwaway checkout. So if main's package.json stays behind, the next
 # regeneration pins to the stale number and walks SDK_VERSION back.
 
 # Dependency lockfile. Fern regenerates it on every SDK regeneration, which


### PR DESCRIPTION
Comment-only follow-up to #33, which removed `package.json` from `.fernignore`. The `src/version.ts` NOTE block still justified the release-time invariant with "package.json is .fernignore'd" — false since that merge, and flagged on [ENG-10145](https://linear.app/hedra/issue/ENG-10145/hedra-node-un-ignore-packagejson-so-regeneration-stamps-the-version) when the flip landed.

The invariant itself — bump `package.json` on main when cutting a release, or the next regeneration walks `SDK_VERSION` back — still holds, for a different reason: regeneration now stamps the manifest too, but only with the number read *from* main's `package.json` itself, a round-trip that can never advance it, and `publish-npm.yml` still only rewrites the copy in the job's throwaway checkout. The rewritten paragraph says exactly that.

No entries added or removed; `git diff` is confined to the NOTE comment.
