### PR TITLE
chore: reset manifest version to 0.9.9 as the computed-release baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hedra-node",
-    "version": "1.0.0",
+    "version": "0.9.9",
     "private": false,
     "repository": {
         "type": "git",


### PR DESCRIPTION
Under the manifest-sourced versioning model that landed in hedra-labs/fern-config#44, this repo's `package.json` at HEAD is the version source of truth: regeneration computes the bump since the last generation and stamps `bump(manifest, class)-dev` into the regen PRs, and release strips the suffix.

The accumulated v3 drift diffs as **major**, and a major bump on `0.9.9` computes exactly `1.0.0` — so after this reset, the next regeneration stamps `1.0.0-dev` and the first release publishes 1.0.0 through the normal computed flow, with no `force_version` bootstrap.

Notes:

- Only the `"version"` field changes. `src/version.ts` (Fern-stamped `SDK_VERSION`) is restamped by regeneration from this baseline, and `pnpm-lock.yaml` does not record the root version, so neither is touched.
- The open Fern regeneration PR stamped `2.0.0-dev` was computed off the old `1.0.0` baseline; the next regeneration after this merges will refresh it. It is intentionally left alone.

Verified: the diff is the single one-line `package.json` change, and the file still parses (`node -e "require('./package.json').version"` → `0.9.9`).
