### PR TITLE
ci: autoland fern-bot regeneration PRs

### DIFF
--- a/.github/workflows/autoland-regen.yml
+++ b/.github/workflows/autoland-regen.yml
@@ -1,0 +1,172 @@
+name: Autoland regeneration PRs
+
+# Lands fern-api[bot] "SDK regeneration" PRs without a human.
+#
+# Responsibility split, mirroring hedra-labs/deployments:
+#   - This workflow closes superseded PRs, rebases the newest onto main,
+#     enables auto-merge, and approves. It never merges.
+#   - GitHub's auto-merge does the landing, once the required checks
+#     (regen-shape + this repo's own CI) are green.
+#
+# Safety: runs on pull_request_target so it can reach the App credentials and
+# executes the workflow definition from main, not from the PR. It never checks
+# out or runs PR code -- commits are replayed as data. The job is gated on the
+# bot's immutable numeric account ID.
+#
+# Deliberately absent: any comparison of the PR's version against main's. Since
+# fern-config#44 a regeneration stamps a computed X.Y.Z-dev that differs from
+# main by design, so such a gate would close every PR.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: autoland-regen
+  cancel-in-progress: false
+
+jobs:
+  autoland:
+    runs-on: ubuntu-latest
+    # Always run on push to main and manual dispatch; on PR events only for
+    # fern-api[bot] regeneration branches targeting main.
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      (startsWith(github.event.pull_request.head.ref, 'fern-bot/') &&
+       github.event.pull_request.base.ref == 'main' &&
+       contains(fromJSON('[115122769]'), github.event.pull_request.user.id))
+    steps:
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.SDK_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SDK_BOT_APP_PRIVATE_KEY }}
+
+      # Minted before checkout so the token installs into the git credential
+      # helper: pushes made with the default GITHUB_TOKEN fire no downstream
+      # workflows, which would leave a rebased head with zero check runs.
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Advance the regeneration queue
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          REPO: ${{ github.repository }}
+          FERN_BOT_ID: "115122769"
+        run: |
+          set -euo pipefail
+
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "$(gh api "/users/${APP_SLUG}[bot]" --jq .id)+${APP_SLUG}[bot]@users.noreply.github.com"
+
+          # Candidates, oldest first. Listed via the REST API rather than
+          # `gh pr list --json author`, which exposes only login/is_bot -- the
+          # authoritative gate is the immutable numeric account ID.
+          mapfile -t queue < <(
+            gh api "repos/${REPO}/pulls?state=open&per_page=100" \
+              --jq "[ .[]
+                      | select(.user.id == ${FERN_BOT_ID})
+                      | select(.head.ref | startswith(\"fern-bot/\"))
+                      | select(.base.ref == \"main\") ]
+                    | sort_by(.created_at)
+                    | .[] | \"\(.number)\t\(.head.ref)\""
+          )
+
+          if [[ "${#queue[@]}" -eq 0 ]]; then
+            echo "No open regeneration PRs."
+            exit 0
+          fi
+
+          # A regeneration PR is a whole snapshot, so an older one carries
+          # strictly less information than a newer one. Close all but the newest.
+          last=$(( ${#queue[@]} - 1 ))
+          for i in $(seq 0 $(( last - 1 )) ); do
+            pr="${queue[$i]%%$'\t'*}"
+            echo "Closing #${pr} as superseded."
+            gh pr close "$pr" --repo "$REPO" \
+              --comment "Superseded by a newer SDK regeneration."
+          done
+
+          pr="${queue[$last]%%$'\t'*}"
+          head_ref="${queue[$last]#*$'\t'}"
+          echo "::group::Head of queue: #${pr} (${head_ref})"
+
+          # Defence in depth. regen-shape is the primary gate and is a required
+          # check; this repeats the two file guards so a bug there cannot
+          # auto-approve a workflow-modifying PR.
+          files="$(gh api "repos/${REPO}/pulls/${pr}/files" --paginate --jq '.[].filename')"
+          if grep -qE '^\.github/' <<<"$files"; then
+            echo "::error::PR #${pr} touches .github/ — refusing to autoland."
+            exit 1
+          fi
+          if grep -qx '\.fernignore' <<<"$files"; then
+            echo "::error::PR #${pr} edits .fernignore — refusing to autoland."
+            exit 1
+          fi
+
+          git fetch origin main
+          git fetch origin "+refs/heads/${head_ref}:refs/remotes/origin/${head_ref}"
+
+          if ! git merge-base --is-ancestor origin/main "origin/${head_ref}"; then
+            echo "#${pr} is behind main; rebasing."
+            git checkout -B "$head_ref" "origin/${head_ref}"
+            # -X theirs resolves conflicting hunks in the PR's favour, which is
+            # correct for generated content. .fernignore'd files never appear in
+            # a regeneration diff, so main's copies of them survive untouched.
+            if ! git rebase -X theirs origin/main; then
+              git rebase --abort || true
+              gh pr comment "$pr" --repo "$REPO" \
+                --body "Autoland: rebase onto \`main\` could not auto-resolve. Leaving this for a human."
+              exit 0
+            fi
+            if git diff --quiet origin/main; then
+              gh pr close "$pr" --repo "$REPO" \
+                --comment "Superseded: this regeneration is already on \`main\`."
+              exit 0
+            fi
+            git push --force-with-lease="${head_ref}:$(git rev-parse "origin/${head_ref}")" \
+              origin "HEAD:${head_ref}"
+            echo "#${pr} rebased and force-pushed; fresh checks will run."
+          fi
+
+          # Auto-merge BEFORE approving. The PR is still BLOCKED for want of a
+          # review here, so --auto always has something to wait for and attaches
+          # reliably. enablePullRequestAutoMerge refuses ("unstable status") on a
+          # PR with nothing left to wait for, which is what a post-approval call
+          # would often hit.
+          if [[ "$(gh pr view "$pr" --repo "$REPO" --json autoMergeRequest --jq '.autoMergeRequest != null')" != "true" ]]; then
+            set +e
+            out="$(gh pr merge --auto --squash "$pr" --repo "$REPO" 2>&1)"; rc=$?
+            set -e
+            echo "$out"
+            if [[ $rc -ne 0 ]]; then
+              if [[ "$out" == *"unstable status"* ]]; then
+                echo "Already fully mergeable; merging directly."
+                gh pr merge --squash "$pr" --repo "$REPO"
+              else
+                exit 1
+              fi
+            fi
+          else
+            echo "Auto-merge already attached."
+          fi
+
+          if [[ "$(gh pr view "$pr" --repo "$REPO" --json reviewDecision --jq .reviewDecision)" != "APPROVED" ]]; then
+            gh pr review --approve "$pr" --repo "$REPO"
+          else
+            echo "Already approved."
+          fi
+
+          echo "::endgroup::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: ci
 
-on: [push]
+# A required status check must not depend on event ordering this repo does not
+# control. Checks appear on regeneration PRs today only because Fern pushes the
+# branch before opening the PR; `pull_request` makes that guaranteed instead of
+# incidental. Same-repo branches get two runs per push as a result -- accepted,
+# and harmless because `cancel-in-progress` is false below.
+on:
+  push:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -47,3 +54,66 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  # Contract for what a fern-api[bot] regeneration may change. Required status
+  # check; autoland-regen.yml will not merge a PR without it. Always runs and
+  # no-ops off fern-bot/ branches so it stays satisfiable on human PRs.
+  #
+  # The version rule is a consistency rule, not a no-change rule: it asserts
+  # that package.json and src/version.ts carry the same string, never what that
+  # string should be. compute_version.py in fern-config owns the number, and
+  # since fern-config#44 regeneration is the mechanism by which versions move
+  # at all -- a rule forbidding the version to change would freeze it forever.
+  regen-shape:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Validate regeneration diff shape
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT" != "pull_request" ]]; then
+            echo "Not a pull_request event — nothing to check."
+            exit 0
+          fi
+          if [[ "$HEAD_REF" != fern-bot/* ]]; then
+            echo "Branch '$HEAD_REF' is not under fern-bot/ — shape check skipped."
+            exit 0
+          fi
+
+          git fetch --no-tags origin main
+          base="$(git merge-base origin/main HEAD)"
+          mapfile -t changed < <(git diff --name-only "$base" HEAD)
+          echo "Changed files (${#changed[@]}):"
+          printf '  %s\n' "${changed[@]}"
+
+          fail=0
+          for f in "${changed[@]}"; do
+            case "$f" in
+              .github/*)
+                echo "FAIL: regeneration must not touch .github/ ($f)"; fail=1 ;;
+              .fernignore)
+                echo "FAIL: regeneration must not edit .fernignore"; fail=1 ;;
+            esac
+          done
+          [[ "$fail" -eq 0 ]]
+
+          manifest="$(jq -r .version package.json)"
+          constant="$(sed -n 's/.*SDK_VERSION[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/version.ts | head -1)"
+          if [[ -z "$constant" ]]; then
+            echo "FAIL: could not read SDK_VERSION from src/version.ts"; exit 1
+          fi
+          if [[ "$manifest" != "$constant" ]]; then
+            echo "FAIL: package.json says '$manifest', src/version.ts says '$constant'"
+            exit 1
+          fi
+          echo "OK: every version-bearing file agrees on '$manifest'"
+
+          echo "OK: regeneration shape check passed."


### PR DESCRIPTION
Adds the two workflow layers that let `fern-api[bot]` SDK regeneration PRs approve and merge themselves in this repo, matching what already landed in hedra-cli (hedra-cli#56) and hedra-python. Task 5 of the SDK regeneration autoland plan.

**Scope stops here, deliberately.** This PR does not enable auto-merge or add required status checks — that is a separate, later step. A required check that does not yet exist on `main` blocks every PR in the repo, including the one that adds it.

## What changed

**`ci.yml` gains a `pull_request` trigger.** It was `on: [push]` only. Checks appear on regeneration PRs today merely because Fern pushes the branch before opening the PR, and because the merge queue's force-push creates a new SHA. That happens to hold, but it makes a required status check depend on event ordering this repo does not control. The accepted cost is that same-repo branches now get two CI runs per push; the existing `concurrency` block already sets `cancel-in-progress: false`, so the pair does not cancel itself.

**`ci.yml` gains `regen-shape`**, the contract for what a regeneration is allowed to change:

1. no file under `.github/` changed — workflows are `.fernignore`d, so a regeneration touching one means something is wrong;
2. `.fernignore` itself unchanged — a PR editing it is editing its own leash;
3. `package.json`'s `.version` agrees with `SDK_VERSION` in `src/version.ts`.

The job always runs and exits 0 immediately when the head branch is not `fern-bot/**`, so it stays satisfiable on ordinary human PRs — including this one.

Rule 3 is a **consistency** rule, not a no-change rule, and the distinction matters. It asserts the two numbers are the same string; it says nothing about what that string should be. `compute_version.py` in fern-config owns the number, and since fern-config#44 regeneration is *the mechanism by which versions move at all* — so a rule forbidding the version to change would not be a stricter policy, it would be a system in which no version ever changes again. What rule 3 catches is a generation writing its version-bearing files inconsistently, which is the real bug behind an `X-Fern-SDK-Version` that disagrees with its own manifest.

**`autoland-regen.yml` is new**, copied byte-identical from hedra-cli's `main` at `5a6e217`. It closes superseded regeneration PRs, rebases the newest onto `main`, attaches auto-merge, and approves — it never merges; GitHub's auto-merge does the landing once the required checks are green. It reads `${{ github.repository }}` rather than being parameterised per repo, and a follow-up adds a drift check enforcing that it stays identical across all three SDK repos, so it should not be edited here.

## Verification

Everything below was run locally against this branch.

- **Byte-identity**: `cmp` against hedra-cli's copy at the pinned SHA — identical, not merely similar.
- **YAML**: both files parse; `ci.yml` exposes jobs `compile`, `test`, `regen-shape` and triggers `push` + `pull_request`.
- **Shell**: every embedded `run:` script passes `bash -n`.
- **`actionlint`**: clean over both files, run as `actionlint -ignore 'create-github-app-token'`. That ignore suppresses two known false positives — actionlint's bundled metadata for `actions/create-github-app-token` is stale, and at v3 `client-id` is supported while `app-id` is deprecated.
- **`regen-shape` guards**, driving the job's real script with synthetic event inputs: `push` event → exits 0; this PR's own branch → exits 0 via the `fern-bot/` early exit; an unrelated human branch → exits 0; and a simulated `fern-bot/` branch carrying this very diff → **fails**, correctly naming both `.github/` files. So the guard is proven in both directions, not just the passing one.
- **Version rule**, both directions, slicing the fragment out of the committed YAML rather than retyping it: on `main` both values extract non-empty and agree (`1.0.0-dev`); perturbing `package.json` to disagree fails and names both values; removing `SDK_VERSION` entirely fails with its own message.

The `pull_request`-triggered CI run on this PR is itself the proof that the new trigger works, and `regen-shape` reporting green here is the proof that the early-exit guard is right.

## Note for review

The plan's version-rule fragment carried an inline comment stating that `main` reads `0.9.9 / 1.0.0`. That measurement is stale — a regeneration has since reconciled both files to `1.0.0-dev`, which is why the rule passes on `main` today. The shell logic is committed exactly as supplied; only that now-false comment was dropped, since the rationale it carried is already stated in the job's header comment without the stale numbers.

Closes ENG-10236
