### PR TITLE
ci: bump actions/checkout to v7 in autoland-regen.yml

### DIFF
--- a/.github/workflows/autoland-regen.yml
+++ b/.github/workflows/autoland-regen.yml
@@ -53,7 +53,7 @@ jobs:
       # Minted before checkout so the token installs into the git credential
       # helper: pushes made with the default GITHUB_TOKEN fire no downstream
       # workflows, which would leave a rebased head with zero check runs.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0


### PR DESCRIPTION
Bumps the single `actions/checkout` reference in `.github/workflows/autoland-regen.yml` from `@v6` to `@v7`. One line, one file.

`autoland-regen.yml` is required to be byte-identical across `hedra-cli`, `hedra-python` and `hedra-node` — a scheduled drift check in `hedra-labs/fern-config`
(`.github/workflows/autoland-drift-check.yml`) enforces that, and it is [currently red](https://github.com/hedra-labs/fern-config/actions/runs/31531044835) on exactly this
difference:

```
-      - uses: actions/checkout@v7     (hedra-cli)
+      - uses: actions/checkout@v6     (hedra-python, hedra-node)
```

`hedra-cli` is already on `@v7`, so the decision is to converge forward rather than pin it back. `hedra-python` gets the identical change in its own PR; the drift check
stays red until both land, which is expected.

### Verification

The file now hashes to the value `hedra-cli`'s copy already has, which is the actual contract the drift check tests:

```console
$ shasum -a 256 .github/workflows/autoland-regen.yml
310087fcdbad82ca91a04a1e4d4fd30f3d681c731b3e2391be07bb48d5dd7318

$ git diff origin/main --stat
 .github/workflows/autoland-regen.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

The workflow still parses as valid YAML. No formatter, linter, or test in this repo covers `.github/workflows/*.yml` (biome's `includes` excludes it and treats it as an
unknown type), so there is nothing further to run against this diff.

### Deliberately not included

`.github/workflows/ci.yml` uses `actions/checkout@v6` in three places and is left alone. The drift check compares only `autoland-regen.yml`, and bumping CI's checkouts
would turn a one-line fix into an untested CI change on a repo whose regeneration pipeline is freshly green.
