### PR TITLE
ci(publish-npm): add a dry_run input to build without publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,6 +16,10 @@ on:
         description: "Version to publish, e.g. 1.0.0 (required: a manual run has no release tag to derive it from)"
         required: true
         type: string
+      dry_run:
+        description: "Build, test and pack, but stop short of uploading to npm"
+        type: boolean
+        default: false
 
 jobs:
   publish:
@@ -99,7 +103,20 @@ jobs:
       - name: Test
         run: pnpm test
 
+      # `npm publish --dry-run` runs the full pack-and-validate path and reports
+      # exactly what would be uploaded, without uploading. A `release: published`
+      # run supplies no inputs, so DRY_RUN is the empty string and the real
+      # publish is what happens -- the default must stay false.
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || secrets.HEDRA_NPM_TOKEN }}
-        run: npm publish --access public
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "::notice::Dry run - packing only; nothing is uploaded to npm."
+            npm publish --access public --dry-run
+          else
+            echo "::notice::Publishing to npm for real."
+            npm publish --access public
+          fi


### PR DESCRIPTION
## What

Adds a `dry_run` boolean input (default `false`) to `publish-npm.yml`'s `workflow_dispatch`, and makes the final `Publish to npm` step honour it. When it is true the step runs
`npm publish --access public --dry-run`, which walks the full pack-and-validate path and reports exactly what would be uploaded, without uploading.

Nothing else changes. The checkout, the version resolution and its semver guard, the `npm version --no-git-tag-version` write, the `src/version.ts` consistency warning, `pnpm build`
and `pnpm test` all stay exactly as they are.

## Why

`environment: npm-publish` sits on the **job**, not on the publish step, so the approval gate wraps checkout, version resolution, build, test and publish together as a single unit.
Approving it publishes; declining it means the build never runs at all. There is no way today to exercise the last mile — install, version write, build, test, pack — and stop short
of the upload.

This is the minimum change that makes build-without-publish expressible. It needs no restructuring of the environment gate, no second workflow, and no change to how the published
version is resolved.

## The default is load-bearing

A `release: published` run supplies no inputs, so `inputs.dry_run` evaluates to the empty string, the `[ "${DRY_RUN}" = "true" ]` test fails, and the real publish is what happens.
The default must stay `false`.

## Verification

Locally, on this branch:

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-npm.yml')); print('parsed OK')"` → `parsed OK`
- `actionlint .github/workflows/publish-npm.yml` → no output

Post-merge:

```
gh workflow run publish-npm.yml --repo hedra-labs/hedra-node -f version=1.0.0 -f dry_run=true
# approve the `npm-publish` environment for that run, then:
curl -s https://registry.npmjs.org/hedra-node | python3 -c "import json,sys; print(json.load(sys.stdin)['dist-tags']['latest'])"   # expect 0.1.2
```

That can be run against `main` before any release exists, because the workflow already accepts an explicit `version` and derives the published version from the release tag rather
than from `package.json` (ENG-10111).

Expect a `src/version.ts` warning on that pre-release run, and do not treat it as a failure: `main` currently carries `SDK_VERSION = "1.0.0-dev"`, so the existing consistency check
will warn that it disagrees with the `1.0.0` being "published". After the real release lands `1.0.0` on `main`, that warning should disappear — and if it does not, that is a genuine
finding.

Closes ENG-10252
