### PR TITLE
ci(publish-npm): attach the packed tarball to the GitHub Release

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,6 +21,12 @@ on:
         type: boolean
         default: false
 
+# `contents: write` is for attaching the packed tarball to the GitHub Release
+# (see the pack/upload steps); npm itself is authenticated with NODE_AUTH_TOKEN,
+# not with the workflow token.
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -102,6 +108,51 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      # npm publishes straight from the working tree, so unlike the Python job
+      # there is no dist/ full of artifacts to attach -- the tarball has to be
+      # made. `npm pack --silent` prints the filename it wrote.
+      - name: Pack the tarball
+        id: pack
+        run: |
+          set -euo pipefail
+          tarball="$(npm pack --silent)"
+          echo "tarball=${tarball}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Packed ${tarball} ($(du -h "${tarball}" | cut -f1))."
+
+      # Attach it to the GitHub Release. npm remains the package's home -- this
+      # is for provenance, attestation checks, and air-gapped installs that
+      # cannot reach the registry.
+      #
+      # Ordered BEFORE the publish deliberately, exactly as in hedra-python#67:
+      # an upload failure here leaves a fully recoverable state, because nothing
+      # is on npm yet and re-running the whole job fixes it. Failing *after* the
+      # publish would leave a split state a re-run cannot repair, since npm
+      # rejects re-publishing a version that already exists.
+      - name: Attach the tarball to the GitHub Release
+        if: ${{ inputs.dry_run != true }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+        run: |
+          set -euo pipefail
+          raw="${RELEASE_TAG:-${INPUT_VERSION:-}}"
+          if [ -z "$raw" ]; then
+            echo "::error::No release tag or version input; cannot locate the Release to upload to."
+            exit 1
+          fi
+          case "$raw" in
+            v*) tag="$raw" ;;
+            *)  tag="v${raw}" ;;
+          esac
+          if ! gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::notice::No GitHub Release ${tag} exists; skipping asset upload."
+            exit 0
+          fi
+          gh release upload "$tag" "$TARBALL" --repo "${{ github.repository }}" --clobber
+          echo "::notice::Attached ${TARBALL} to ${tag}."
 
       # `npm publish --dry-run` runs the full pack-and-validate path and reports
       # exactly what would be uploaded, without uploading. A `release: published`


### PR DESCRIPTION
Attaches the packed npm tarball to the GitHub Release that triggers a publish, so each release carries the artifact alongside the registry copy. This is the npm counterpart of hedra-labs/hedra-python#67, which did the same for the wheel and sdist.

## Why `contents: write`

`publish-npm.yml` had no `permissions:` block at all, so the job ran with the repository's default token permissions. `gh release upload` needs `contents: write`; without it it fails with `Resource not accessible by integration (HTTP 403)` — the exact failure that blocked fern-config's release path (run 31548785013, fixed in fern-config#58), and the reason #67 changed `contents: read` to `contents: write`.

Worth being explicit about the side effect: adding a workflow-level `permissions:` block **restricts** the token to exactly what is listed, dropping every other scope to none. That is intended and safe here — nothing in this workflow needs a scope other than `contents`, and npm is authenticated with `NODE_AUTH_TOKEN` (a secret), not with the workflow token.

## Why there is an extra `npm pack` step, where #67 needed none

The Python job runs `poetry build`, which leaves `dist/*.whl` and `dist/*.tar.gz` on disk for the upload step to pick up. npm has no equivalent step: `npm publish` packs internally and uploads in one action, leaving nothing behind. So the tarball has to be created explicitly with `npm pack`, whose `--silent` output is the filename it wrote.

Placement is load-bearing. The pack must come after `Write the resolved version into package.json` (or the tarball carries the wrong version — the filename is derived from `package.json`) and after `Build` (or `dist/` is missing from it, since `files` is `["dist", "reference.md", "README.md", "LICENSE"]`). Between `Test` and `Publish to npm` satisfies both.

The upload is ordered **before** the publish deliberately, exactly as in #67: an upload failure there leaves a fully recoverable state, because nothing is on npm yet and re-running the whole job fixes it. Failing *after* the publish would leave a split state a re-run cannot repair, since npm rejects re-publishing a version that already exists.

### Known limitation, accepted deliberately

The attached tarball is a re-pack of the same tree, not literally the bytes `npm publish` uploads, because the publish step packs again internally. In practice the two are identical — same tree, same `files` config, same npm version. Making them byte-identical by construction would mean changing the publish step to `npm publish "$TARBALL"`, which touches the one step in this workflow that is both gated and working. Not worth it here; if an attestation requirement ever demands it, that is the change to make.

## Verification

This repo has no YAML linting in CI, and none of its three required checks (`compile`, `test`, `regen-shape`) read `.github/workflows/` — a workflow-syntax regression here would merge green. So the checks below were run locally and are the real signal:

- YAML parses, and the parsed `permissions` block reads `{'contents': 'write'}`:

  ```
  python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/publish-npm.yml')); print('parsed OK'); print(d['permissions'])"
  # parsed OK
  # {'contents': 'write'}
  ```

- `bash -n` passes over both new steps' script bodies (with `${{ }}` expressions substituted first, as GitHub does textually before the shell runs).
- Step order confirmed: `… Build, Test, Pack the tarball, Attach the tarball to the GitHub Release, Publish to npm`.
- `npm pack --silent` checked against a fixture built from this repo's real `package.json`: it prints exactly one line (`hedra-node-2.0.0.tgz`, trailing newline only), so `$(npm pack --silent)` is a clean single token for `$GITHUB_OUTPUT`; and the resulting tarball contains `package/dist/…` when `dist/` is present, confirming the post-`Build` placement.

Deliberately **not** exercised end-to-end: `v2.0.0`'s `publish-npm` run is being held at the `npm-publish` environment gate, and this change is for the *next* publish — no run was approved or dispatched.

Closes ENG-10279
