### PR TITLE
ci(publish-npm): key the concurrency group on the version

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,6 +27,25 @@ on:
 permissions:
   contents: write
 
+# Keyed on the VERSION, not just the workflow. Two runs for the same version
+# must not interleave their `npm version` writes over one checkout, and an npm
+# publish is irreversible -- that is what this group is for. It is scoped by
+# version from the start so it can never cause the deadlock a workflow-wide
+# group caused in hedra-python: there a publish parked at its environment gate
+# held every later publish behind it forever (measured 2026-08-12: v1.0.0's run
+# sat `pending` behind v2.0.0's held run and only moved once the held run was
+# cancelled). Here, distinct versions queue independently.
+#
+# `github.event.release.tag_name || inputs.version` covers both trigger paths:
+# a `release: published` run has the tag, a `workflow_dispatch` run has the
+# input. Tags are `v`-prefixed and the input is bare, so one version reached
+# both ways yields two group names -- acceptable, since the risk guarded against
+# is two *concurrent* runs, and the realistic collisions (a re-run of the same
+# release, or two dispatches of the same version) stay covered. See ENG-10281.
+concurrency:
+  group: publish-npm-${{ github.event.release.tag_name || inputs.version }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Gives `publish-npm.yml` a **version-scoped** concurrency group, so two runs publishing the *same* version serialise while runs for *different* versions queue independently.

```yaml
concurrency:
  group: publish-npm-${{ github.event.release.tag_name || inputs.version }}
  cancel-in-progress: false
```

`github.event.release.tag_name || inputs.version` covers both trigger paths: a `release: published` run has the tag, a `workflow_dispatch` run has the input.

## This is an addition, not the edit the ticket describes

Worth flagging before review, because it differs from ENG-10281 as written. The ticket lists hedra-node's current group as `publish-npm` and asks for the `group:` line to be replaced. **That block does not exist in this repo** — so there was no line to replace, and this PR adds the block instead.

Verified three ways:

- `origin/main`'s `publish-npm.yml` contains no `concurrency` key at all.
- `git log --all -S 'concurrency' -- .github/workflows/publish-npm.yml` returns nothing: the string has never appeared in that file, in any commit, on any branch.
- The `v2.0.0` tag's copy of the file has none either.

A follow-on correction: the deadlock ENG-10281 was filed for **could not have happened here**. `publish-npm` #3 (`v2.0.0`) is indeed sitting `waiting`, but purely at its own `npm-publish` approval gate — with no concurrency group in either the `main` or the `v2.0.0` copy of the workflow, it is not gating anything, and a `1.0.0` release firing today would have gone straight to its own gate rather than queueing behind it. The hedra-python half of the ticket is a genuine bug fix; this half is not.

## Why add it rather than close the ticket for this repo

Two reasons, and it is strictly safer than either alternative:

1. **It supplies protection this repo actually lacks.** The property the group exists for — two runs for one version must not interleave their `npm version` writes over a single checkout, against an irreversible npm upload — was simply unguarded here. That gap is real even though the deadlock wasn't.
2. **It cannot reintroduce the deadlock.** The group is version-scoped from birth, so it never passes through the workflow-wide state that bit hedra-python.

It also lands the end state ENG-10281 specifies (`concurrency.group` as an expression, `cancel-in-progress: false`); only the starting point was mis-described. If you would rather this repo keep no group at all, this PR is the thing to drop — say so and I'll close it.

## Verification

CI cannot check this: `compile`, `test` and `regen-shape` are the required checks and none of them read `.github/workflows/`, so a workflow-syntax regression here would merge green. The local checks are the only real signal.

- `python3 -c "import yaml; yaml.safe_load(...)"` → `parsed OK`.
- Parsed `concurrency.group` is `publish-npm-${{ github.event.release.tag_name || inputs.version }}` — contains `${{`, i.e. an expression, not a literal. `cancel-in-progress` parses as exactly `False`.
- `actionlint .github/workflows/publish-npm.yml` → clean. This is the stronger signal of the two: actionlint type-checks `${{ }}` expressions against each trigger's event context, so it would have rejected `github.event.release.tag_name` or `inputs.version` had either been invalid for these triggers.
- Diff is 19 added lines in one file. Nothing else touched — in particular not `package.json`, `src/version.ts`, `pnpm-lock.yaml`, or any other workflow.
- Not run, and why: `biome` handles JS/TS/JSON and sets `ignoreUnknown: true`, so it ignores `.yml` outright; `build`/`vitest` have no changed TypeScript to cover.

No publish run was approved, cancelled or dispatched.

`cancel-in-progress: false` is deliberate — a publish must never be cancelled mid-upload by a newer run.

Branched from `origin/main` (`8bcbd2d`). Does not build on #63 (ENG-10279), which had already merged by the time this started.

Closes ENG-10281
