### PR TITLE
ci(workflows): validate YAML/JSON and shell-check every run block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,220 @@ jobs:
           echo "OK: every version-bearing file agrees on '$manifest'"
 
           echo "OK: regeneration shape check passed."
+
+  # Nothing else in this workflow reads .github/ -- compile, test and
+  # regen-shape all stop at the TypeScript. So a workflow with broken YAML, or
+  # a `run:` block with broken shell, merged green and surfaced only when that
+  # workflow next fired: for publish-npm.yml that is a release being cut, and
+  # for autoland-regen.yml a regeneration being landed. Both are the most
+  # expensive moments to discover it.
+  #
+  # Validate only, never rewrite. autoland-regen.yml must stay byte-identical
+  # across all three SDK repos and autoland-drift-check.yml enforces that, so a
+  # formatter here would actively break landing.
+  config-syntax:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+
+      - name: Set up python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Install PyYAML
+        run: python -m pip install --quiet pyyaml
+
+      - name: Validate config syntax (JSON + YAML)
+        run: |
+          python - <<'PY'
+          import json
+          import subprocess
+          import sys
+
+          import yaml
+
+          # git ls-files, not glob: glob("**/*.yml") skips dot-prefixed path
+          # components, so every .github/ workflow goes unparsed -- which is
+          # precisely the hole this job closes. fern-config shipped that bug
+          # and fixed it this way (ENG-10238). Tracked-only also keeps
+          # node_modules/ out should an install step ever land above this one.
+          tracked = subprocess.run(
+              ["git", "ls-files", "-z", "*.json", "*.yml", "*.yaml"],
+              check=True,
+              stdout=subprocess.PIPE,
+              text=True,
+          ).stdout
+          paths = sorted(p for p in tracked.split("\0") if p)
+
+          # A pathspec that matches nothing would otherwise pass green, which
+          # is the exact shape of the bug above.
+          if not paths:
+              sys.exit("::error::no tracked config files enumerated")
+
+          errors = 0
+          for path in paths:
+              try:
+                  with open(path, encoding="utf-8") as fh:
+                      if path.endswith(".json"):
+                          json.load(fh)
+                      else:
+                          list(yaml.safe_load_all(fh))
+              except Exception as exc:  # noqa: BLE001 - report and continue
+                  print(f"::error file={path}::{exc}")
+                  errors += 1
+
+          if errors:
+              sys.exit(1)
+          print(f"OK: parsed {len(paths)} config file(s)")
+          PY
+
+      # A YAML parse says nothing about the shell inside a run: block, and
+      # publish-npm.yml and autoland-regen.yml are mostly shell inside YAML.
+      - name: Shell-syntax-check every run block
+        run: |
+          python - <<'PY'
+          import re
+          import subprocess
+          import sys
+
+          import yaml
+
+          # GitHub substitutes its own expressions before any shell sees them,
+          # so they are not shell syntax. Reduce each to one plain word,
+          # preserving line count (backslash-newline continues the line) so the
+          # line numbers reported below still point at the right source line.
+          EXPR = re.compile(r"\$\{\{.*?\}\}", re.S)
+
+
+          class Src(str):
+              """A YAML string that remembers which line it came from."""
+
+              line = 0
+              block = False
+
+
+          def _scalar(loader, node):
+              s = Src(loader.construct_scalar(node))
+              s.line = node.start_mark.line
+              s.block = node.style in ("|", ">")
+              return s
+
+
+          class Loader(yaml.SafeLoader):
+              pass
+
+
+          Loader.add_constructor("tag:yaml.org,2002:str", _scalar)
+
+          CHECKERS = {"bash": ["bash", "-n"], "sh": ["sh", "-n"]}
+
+
+          def default_shell(runs_on):
+              # GitHub's own default: bash on Linux and macOS, pwsh on Windows.
+              return "pwsh" if "windows" in str(runs_on).lower() else "bash"
+
+
+          def step_lists(doc):
+              # Both shapes that carry steps[]: a workflow and a composite
+              # action. Enumerating every tracked YAML rather than a fixed
+              # path means a workflow added somewhere new cannot go unchecked.
+              jobs = doc.get("jobs")
+              if isinstance(jobs, dict):
+                  for name, job in jobs.items():
+                      if isinstance(job, dict):
+                          yield name, job
+              runs = doc.get("runs")
+              if isinstance(runs, dict) and "steps" in runs:
+                  yield "runs", runs
+
+
+          tracked = subprocess.run(
+              ["git", "ls-files", "-z", "*.yml", "*.yaml"],
+              check=True,
+              stdout=subprocess.PIPE,
+              text=True,
+          ).stdout
+          paths = sorted(p for p in tracked.split("\0") if p)
+
+          errors = 0
+          checked = 0
+          skipped = []
+
+          for path in paths:
+              try:
+                  with open(path, encoding="utf-8") as fh:
+                      doc = yaml.load(fh, Loader=Loader)
+              except Exception as exc:  # noqa: BLE001 - prior step has detail
+                  print(f"::error file={path}::unparseable, cannot walk it: {exc}")
+                  errors += 1
+                  continue
+              if not isinstance(doc, dict):
+                  continue
+              wf_default = ((doc.get("defaults") or {}).get("run") or {}).get("shell")
+
+              for job_name, job in step_lists(doc):
+                  steps = job.get("steps")
+                  if not isinstance(steps, list):
+                      continue
+                  job_default = ((job.get("defaults") or {}).get("run") or {}).get("shell")
+                  for i, step in enumerate(steps):
+                      if not isinstance(step, dict):
+                          continue
+                      run = step.get("run")
+                      if not isinstance(run, str):
+                          continue
+                      where = f"{path}:{job_name}:steps[{i}]"
+                      shell = (
+                          step.get("shell")
+                          or job_default
+                          or wf_default
+                          or default_shell(job.get("runs-on"))
+                      )
+                      if shell not in CHECKERS:
+                          skipped.append(f"{where} (shell: {shell})")
+                          continue
+
+                      first = getattr(run, "line", 0) + 1
+                      if getattr(run, "block", False):
+                          first += 1  # a block scalar starts the line after run:
+                      script = EXPR.sub(
+                          lambda m: "__GHA_EXPR__" + "\\\n" * m.group(0).count("\n"),
+                          run,
+                      )
+
+                      # Fed on stdin, never written to disk: this job validates,
+                      # and must not be able to touch a file under .github/.
+                      proc = subprocess.run(
+                          CHECKERS[shell],
+                          input=script,
+                          stderr=subprocess.PIPE,
+                          text=True,
+                      )
+                      checked += 1
+                      if proc.returncode == 0:
+                          continue
+                      errors += 1
+                      # Rewrite "bash: line N: ..." into the real file:line.
+                      for raw in proc.stderr.strip().splitlines():
+                          msg = re.sub(r"^\w+: ", "", raw)
+                          m = re.match(r"line (\d+): (.*)", msg)
+                          if m:
+                              line = first + int(m.group(1)) - 1
+                              print(f"::error file={path},line={line}::{where}: {m.group(2)}")
+                          else:
+                              print(f"::error file={path}::{where}: {msg}")
+
+          for s in skipped:
+              print(f"note: not a POSIX shell, skipped: {s}")
+
+          # A walk that matches nothing must not pass green -- that silent-skip
+          # shape is the whole reason this job exists.
+          if not checked:
+              sys.exit("::error::no run blocks were found to check")
+          if errors:
+              sys.exit(f"{errors} error(s); see the annotations above")
+          print(f"OK: shell-parsed {checked} run block(s) across {len(paths)} YAML file(s)")
+          PY


### PR DESCRIPTION
Adds a `config-syntax` job to `ci.yml` that parses every tracked YAML/JSON file and `bash -n`s the shell inside every `run:` block.

Nothing in this repo's CI read `.github/` at all. `compile`, `test` and `regen-shape` all stop at the TypeScript, and biome — which backs `pnpm check` — has no YAML parser
and runs with `ignoreUnknown: true`, so it skips workflow files silently. A workflow with broken YAML, or a `run:` block with broken shell, merged green and surfaced only when
that workflow next fired: for `publish-npm.yml` that moment is a release being cut, and for `autoland-regen.yml` a regeneration being landed. Those are the two most expensive
moments to find out.

This is not hypothetical. Three separate workflow changes landed here today (#63, #65, #59), and each of their tickets had to instruct the session to run parse checks *locally*,
because CI would not. That instruction was a workaround for this gap, written three times.

## What the job does

**1. Parses every tracked YAML and JSON file.** Enumerated with `git ls-files`, not a glob. `glob("**/*.yml")` skips dot-prefixed path components, so `.github/` goes unparsed —
which is exactly the hole being closed. `fern-config` shipped that same bug and fixed it the same way (ENG-10238); this copies the shape of its working `ci.yml` step, so the two
repos stay recognisably the same check. An empty enumeration is a hard failure rather than a green pass, since "matched nothing" is precisely how the original bug hid.

**2. Shell-syntax-checks every `run:` block.** A YAML parse says nothing about the shell inside, and `publish-npm.yml` and `autoland-regen.yml` are largely shell embedded in YAML.
The step walks `jobs.*.steps[].run`, resolves the effective shell (step → job `defaults` → workflow `defaults` → GitHub's own default, which is `pwsh` on a Windows runner and
`bash` elsewhere), and pipes each block to `bash -n` / `sh -n`. Anything on a non-POSIX shell is printed as skipped rather than passed over in silence.

Details worth knowing:

- **Line numbers point at the real file.** PyYAML's scalar marks give the source line of each `run:` block, so `bash: line 3` becomes an `::error file=…,line=123::` annotation on
  the right line of the right file. Verified exact below.
- **GitHub expressions are neutralised before the parse**, since GitHub substitutes them before any shell sees them — they aren't shell syntax. Each is reduced to one plain word,
  preserving line count so the annotations stay accurate.
- **Nothing is ever written.** Blocks are fed to `bash -n` on stdin; the job holds no temp file and cannot touch a path under `.github/`. This matters here —
  `autoland-regen.yml` must stay byte-identical across all three SDK repos and `autoland-drift-check.yml` enforces it, so a formatter would actively break landing. Validate only.
- **Enumeration is by content, not by path.** It walks every tracked `.yml`/`.yaml` and picks up anything carrying `jobs.*.steps[]` or a composite action's `runs.steps[]`, so a
  workflow added in a new location cannot go unchecked — the same silent-skip failure mode this job exists to prevent.

## Verification

Both steps were extracted verbatim from the committed `ci.yml` and executed, so what ran is exactly what the runner will run.

**Passes on `main` as it stands:**

```
$ Validate config syntax (JSON + YAML)
OK: parsed 15 config file(s)                                     EXIT=0

$ Shell-syntax-check every run block
OK: shell-parsed 19 run block(s) across 7 YAML file(s)           EXIT=0
```

19 blocks is 16 pre-existing plus this job's own 3 — the check covers itself.

**Bad indent** — `uses:` over-indented by two spaces in `autoland-regen.yml`:

```
::error file=.github/workflows/autoland-regen.yml::mapping values are not allowed here
  in ".github/workflows/autoland-regen.yml", line 48, column 15
EXIT=1
```

**Unbalanced `if`** — the closing `fi` deleted from `publish-npm.yml`'s SDK_VERSION check:

```
$ Validate config syntax (JSON + YAML)
OK: parsed 15 config file(s)                                     EXIT=0   <-- the YAML is still valid
$ Shell-syntax-check every run block
::error file=.github/workflows/publish-npm.yml,line=123::.github/workflows/publish-npm.yml:publish:steps[6]: syntax error: unexpected end of file from `if' command on line 3
EXIT=1
```

That contrast is the point of step 2: the file parses perfectly as YAML, and the release path is broken anyway.

**Line mapping is exact** — a stray `fi` inserted at line 92 of `ci.yml` is reported at line 92, not at the top of the block:

```
::error file=.github/workflows/ci.yml,line=92::.github/workflows/ci.yml:regen-shape:steps[1]: syntax error near unexpected token `fi'
```

Neither broken version is committed; each was reverted immediately after the run. `git diff` on this branch is 217 insertions and 0 deletions, touching `ci.yml` only.

Independently, `actionlint` 1.7.12 (with its shellcheck integration) passes clean on the new `ci.yml`, confirming GitHub will accept the job's schema and expressions.

**Confirmed on the real runner.** This PR's own CI run has `config-syntax` green alongside `compile`, `test` and `regen-shape`, with the two steps printing exactly what they
printed locally:

```
Validate config syntax (JSON + YAML)   OK: parsed 15 config file(s)
Shell-syntax-check every run block     OK: shell-parsed 19 run block(s) across 7 YAML file(s)
```

The whole job takes 8 seconds, so it adds nothing meaningful to CI time.

## Not done, and why

**Not added to the required checks for `main`.** Doing it now would strand the in-flight release PRs: a required check only reports on branches that actually contain the job, so
every PR opened before this merges would block forever on a check that never runs. Both `v1.0.0` and `v2.0.0` are cut and held at the publish gate right now, which is the wrong
week to wedge the queue. The safe order is merge first, then add `config-syntax` alongside `compile`, `test` and `regen-shape` in branch protection. Until then it still goes red
visibly on the PR, which is most of the value.

**`actionlint` not wired into CI.** It's worth having eventually, but it currently fails this repo on a false positive: it reports that `autoland-regen.yml` should use `app-id`
instead of `client-id` for `actions/create-github-app-token@v3`. The action's own `action.yml` says the opposite — `client-id` is current and `app-id` carries
`deprecationMessage: "Use 'client-id' instead."` — so actionlint's bundled metadata is stale. Adopting it as-is would mean either a permanently red check or editing
`autoland-regen.yml` to use a deprecated input, and that file must stay byte-identical across three repos. Deferred deliberately; it is an addition to the two checks here, never a
substitute, since neither its schema check nor its shellcheck pass replaces an explicit `bash -n` over each block.

Closes ENG-10289
