### PR TITLE
ci(autoland): land regen PRs with a merge commit, not a squash

### DIFF
--- a/.github/workflows/autoland-regen.yml
+++ b/.github/workflows/autoland-regen.yml
@@ -180,17 +180,20 @@ jobs:
             echo "#${pr} is behind main; merging main in."
             git checkout -B "$head_ref" "origin/${head_ref}"
             # MERGE, not rebase (ENG-10280). A rebase rewrites every commit on
-            # this branch — including the one Fern recorded as the generation —
-            # so the recorded SHA is orphaned regardless of how the PR is later
-            # landed. A merge leaves the original commits in place and reachable.
+            # this branch — including the one Fern Replay recorded as the
+            # generation — so the recorded SHA is orphaned regardless of how the
+            # PR is later landed, and Replay then persists `user_owned: true`
+            # onto patches whose ownership it merely could not verify. That
+            # write is irreversible. A merge leaves the original commits in
+            # place and reachable.
             #
             # THE FLAG INVERTS BETWEEN THE TWO COMMANDS. `rebase -X theirs` and
             # `merge -X ours` both mean "resolve conflicting hunks in the PR's
             # favour", which is what generated content wants; the ours/theirs
             # roles swap because rebase replays our commits onto upstream.
-            # Measured in a scratch repo, not reasoned about. .fernignore'd files
-            # never appear in a regeneration diff either way, so main's copies of
-            # them survive untouched.
+            # Measured in a scratch repo, not reasoned about. .fernignore'd
+            # files never appear in a regeneration diff either way, so main's
+            # copies of them survive untouched.
             if ! git merge -X ours --no-edit origin/main; then
               git merge --abort || true
               gh pr comment "$pr" --repo "$REPO" \
@@ -209,24 +212,21 @@ jobs:
 
           # Land regeneration PRs with a MERGE COMMIT, not a squash (ENG-10280).
           # A squash writes a brand-new commit to main and the branch is then
-          # deleted, so the SHA Fern recorded as the generation is orphaned —
-          # which is why every regeneration logged "Base generation <sha> is
-          # unreachable", and, worse, why Replay persisted `user_owned: true`
-          # onto patches whose ownership it merely could not verify. That write
-          # is not reversible. ENG-10280 and hedra-labs/hedra-cli#71 carry the
-          # measurement; do not "fix" the warning by fetching deeper, the clone
-          # is complete and the object is gone.
+          # deleted, so the SHA Fern Replay recorded as the generation is
+          # orphaned — which is why every regeneration logged "Base generation
+          # <sha> is unreachable", and why Replay then wrote `user_owned: true`
+          # onto patches it merely could not verify. Do not "fix" that warning
+          # by fetching deeper: the clone is complete, the object is gone.
           #
-          # This needs `allow_merge_commit: true` on the repo. Squash can stay
+          # Needs `allow_merge_commit: true` on the repo. Squash can stay
           # enabled for humans — this only picks the strategy for regeneration
-          # PRs. If merge commits are disabled we fall back rather than stall
-          # regeneration entirely, but loudly, because the fallback re-opens
-          # ENG-10280.
+          # PRs. Where merge commits are disabled we fall back rather than stall
+          # regeneration, but loudly, because the fallback re-opens ENG-10280.
           if [[ "$(gh api "repos/${REPO}" --jq '.allow_merge_commit')" == "true" ]]; then
             strategy="--merge"
           else
             strategy="--squash"
-            echo "::warning::merge commits are disabled on ${REPO}; falling back to --squash. Recorded generation SHAs will be orphaned — see ENG-10280 and hedra-labs/hedra-cli#71."
+            echo "::warning::merge commits are disabled on ${REPO}; falling back to --squash. Recorded generation SHAs will be orphaned — see ENG-10280."
           fi
 
           # Auto-merge BEFORE approving. The PR is still BLOCKED for want of a

--- a/.github/workflows/autoland-regen.yml
+++ b/.github/workflows/autoland-regen.yml
@@ -177,15 +177,24 @@ jobs:
           git fetch origin "+refs/heads/${head_ref}:refs/remotes/origin/${head_ref}"
 
           if ! git merge-base --is-ancestor origin/main "origin/${head_ref}"; then
-            echo "#${pr} is behind main; rebasing."
+            echo "#${pr} is behind main; merging main in."
             git checkout -B "$head_ref" "origin/${head_ref}"
-            # -X theirs resolves conflicting hunks in the PR's favour, which is
-            # correct for generated content. .fernignore'd files never appear in
-            # a regeneration diff, so main's copies of them survive untouched.
-            if ! git rebase -X theirs origin/main; then
-              git rebase --abort || true
+            # MERGE, not rebase (ENG-10280). A rebase rewrites every commit on
+            # this branch — including the one Fern recorded as the generation —
+            # so the recorded SHA is orphaned regardless of how the PR is later
+            # landed. A merge leaves the original commits in place and reachable.
+            #
+            # THE FLAG INVERTS BETWEEN THE TWO COMMANDS. `rebase -X theirs` and
+            # `merge -X ours` both mean "resolve conflicting hunks in the PR's
+            # favour", which is what generated content wants; the ours/theirs
+            # roles swap because rebase replays our commits onto upstream.
+            # Measured in a scratch repo, not reasoned about. .fernignore'd files
+            # never appear in a regeneration diff either way, so main's copies of
+            # them survive untouched.
+            if ! git merge -X ours --no-edit origin/main; then
+              git merge --abort || true
               gh pr comment "$pr" --repo "$REPO" \
-                --body "Autoland: rebase onto \`main\` could not auto-resolve. Leaving this for a human."
+                --body "Autoland: merging \`main\` into this branch could not auto-resolve. Leaving this for a human."
               exit 0
             fi
             if git diff --quiet origin/main; then
@@ -195,7 +204,29 @@ jobs:
             fi
             git push --force-with-lease="${head_ref}:$(git rev-parse "origin/${head_ref}")" \
               origin "HEAD:${head_ref}"
-            echo "#${pr} rebased and force-pushed; fresh checks will run."
+            echo "#${pr} has main merged in and was pushed; fresh checks will run."
+          fi
+
+          # Land regeneration PRs with a MERGE COMMIT, not a squash (ENG-10280).
+          # A squash writes a brand-new commit to main and the branch is then
+          # deleted, so the SHA Fern recorded as the generation is orphaned —
+          # which is why every regeneration logged "Base generation <sha> is
+          # unreachable", and, worse, why Replay persisted `user_owned: true`
+          # onto patches whose ownership it merely could not verify. That write
+          # is not reversible. ENG-10280 and hedra-labs/hedra-cli#71 carry the
+          # measurement; do not "fix" the warning by fetching deeper, the clone
+          # is complete and the object is gone.
+          #
+          # This needs `allow_merge_commit: true` on the repo. Squash can stay
+          # enabled for humans — this only picks the strategy for regeneration
+          # PRs. If merge commits are disabled we fall back rather than stall
+          # regeneration entirely, but loudly, because the fallback re-opens
+          # ENG-10280.
+          if [[ "$(gh api "repos/${REPO}" --jq '.allow_merge_commit')" == "true" ]]; then
+            strategy="--merge"
+          else
+            strategy="--squash"
+            echo "::warning::merge commits are disabled on ${REPO}; falling back to --squash. Recorded generation SHAs will be orphaned — see ENG-10280 and hedra-labs/hedra-cli#71."
           fi
 
           # Auto-merge BEFORE approving. The PR is still BLOCKED for want of a
@@ -205,13 +236,13 @@ jobs:
           # would often hit.
           if [[ "$(gh pr view "$pr" --repo "$REPO" --json autoMergeRequest --jq '.autoMergeRequest != null')" != "true" ]]; then
             set +e
-            out="$(gh pr merge --auto --squash "$pr" --repo "$REPO" 2>&1)"; rc=$?
+            out="$(gh pr merge --auto "$strategy" "$pr" --repo "$REPO" 2>&1)"; rc=$?
             set -e
             echo "$out"
             if [[ $rc -ne 0 ]]; then
               if [[ "$out" == *"unstable status"* ]]; then
                 echo "Already fully mergeable; merging directly."
-                gh pr merge --squash "$pr" --repo "$REPO"
+                gh pr merge "$strategy" "$pr" --repo "$REPO"
               else
                 exit 1
               fi


### PR DESCRIPTION
The hedra-node copy of the autoland change on ENG-10280. Same file, same content, as hedra-labs/hedra-cli#75 and the hedra-python companion — see "Land these as a batch" below.

**This is a no-op until someone flips `allow_merge_commit` on this repo**, so it is safe to land in any order relative to that setting.

## What it changes

Autoland discards the commit Fern records as the generation, in two independent places:

- `git rebase -X theirs origin/main` (~line 185) rewrites every commit on the branch, including the generation commit, whenever the PR is behind `main`.
- `gh pr merge --squash` writes a brand-new commit to `main`, and `delete_branch_on_merge` then removes the only remaining reference.

Either one alone orphans the recorded SHA. In hedra-cli that is what emits `Base generation <sha> is unreachable` every run and — the part that actually bites — what makes Replay persist `user_owned: true` onto patches whose
ownership it merely could not verify. That write is irreversible: `resolveCanonical()` short-circuits on the flag and never re-resolves.

So:

- **rebase → merge.** `git merge -X ours --no-edit origin/main` keeps the original commits in place and reachable.
- **strategy is read from the repo.** `gh api repos/$REPO --jq .allow_merge_commit` picks `--merge`, or falls back to `--squash` with a `::warning::`.

## Why this repo needs it, given it shows no damage today

hedra-node has 11 of 12 recorded generations already orphaned, but its three patches are all anchored to `f8f3d056` — a commit that landed on `main` before the squash era and is still reachable, so ownership still resolves
cleanly. The one `user_owned: true` patch here, `patch-6170698b` (`.gitignore`), is creation-only and was born that way at #49; it is not a fallback flip.

That makes this repo early, not immune. The next customization Replay records gets anchored to a post-squash generation and hits the identical trap. Nothing here would stop it.

No ledger repair is needed, and none is included — `.fern/**` is untouched. The one-time repair on ENG-10280 applies to hedra-cli only.

## The flag inverts — this is the part to review carefully

`rebase -X theirs` and `merge -X ours` mean the *same thing*: resolve conflicting hunks in the PR's favour, which is what generated content wants. The `ours`/`theirs` roles swap because rebase replays our commits onto upstream.
Getting it backwards would quietly discard the regeneration instead of landing it, so it is worth a second pair of eyes.

Re-measured in a scratch repo for this port rather than carried over on trust — conflicting edit on a bot branch, `main` moved underneath:

```
rebase -X theirs main  -> content=BOT   original bot commit unreachable
merge  -X theirs main  -> content=MAIN  <- would silently clobber the regen
merge  -X ours   main  -> content=BOT   original bot commit REACHABLE  ✓
```

## Land these as a batch

`.github/workflows/autoland-regen.yml` is a replicated file, not a reusable workflow, and fern-config's `autoland-drift-check.yml` fails on a daily cron when the three SDK copies stop being byte-identical. So hedra-cli#75,
the hedra-python companion and this PR should land together.

**The drift check goes red between the first merge and the third. That is its documented normal failure mode during a three-repo rollout, not a defect** — it compares copies, and mid-rollout the copies genuinely differ.
It goes green on its own once the last one lands.

The file here is the canonical version, byte-identical to what hedra-cli#75 serves at its head:

```
$ shasum -a 256 .github/workflows/autoland-regen.yml
6acc87a4a35e26ad4a60e394f0e92e13b5ffdf3bbe4d99ca91750d82b8f13b55
```

It is repo-agnostic by design — it reads `${{ github.repository }}`, names no repo and references no repo-local path — so nothing in it needed adapting for hedra-node. (The first commit on this branch hand-ported the change
and re-pointed two comments at a repo-local file; the second replaces that with the canonical file verbatim. The executable lines are identical between the two commits — the correction is comment prose only.)

## Rollout

`allow_merge_commit` is `false` on this repo today, so the preflight resolves `strategy=--squash` and behaviour is byte-for-byte what it is now:

```
$ gh api repos/hedra-labs/hedra-node --jq '{allow_merge_commit, allow_squash_merge, allow_rebase_merge, delete_branch_on_merge}'
{"allow_merge_commit":false,"allow_rebase_merge":false,"allow_squash_merge":true,"delete_branch_on_merge":true}
```

Flipping it does **not** require disabling squash — squash stays available for human PRs; this only selects the strategy for regeneration PRs. When merge commits are disabled the fallback is loud rather than silent, because
falling back re-opens the bug. The setting flip is deliberately not part of this PR.

## Verification

- `.github/workflows/autoland-regen.yml` parses as YAML; all 15 tracked JSON/YAML files parse. This is ci.yml's own `config-syntax` job, re-run locally against the change.
- `bash -n` and `shellcheck -S warning` clean over all 19 `run` blocks in the repo, including the edited one. Re-run after the canonical swap.
- `actionlint` output is byte-identical to its output on `origin/main`'s copy: the two `create-github-app-token` findings at lines 48–50 are pre-existing stale action metadata, untouched by this diff.
- No hardcoded `--squash` remains on either `gh pr merge` call — the only occurrences left are the fallback assignment and the warning text.
- Preflight expression checked against the live API (returns `false`, quoted above).
- `git diff --name-only origin/main` lists one file. Nothing under `.fern/`.
- Not executed end-to-end: that needs a regeneration, which is off-limits. The `-X` semantics are the part that could be tested directly, and were.

Refs ENG-10280
