### PR TITLE
ci(autoland): subject regen merge commits so Replay finds the anchor

### DIFF
--- a/.github/workflows/autoland-regen.yml
+++ b/.github/workflows/autoland-regen.yml
@@ -222,10 +222,42 @@ jobs:
           # enabled for humans — this only picks the strategy for regeneration
           # PRs. Where merge commits are disabled we fall back rather than stall
           # regeneration, but loudly, because the fallback re-opens ENG-10280.
+          #
+          # Name the merge commit so Replay's generation scan can still find an
+          # anchor (ENG-10280, second half). ReplayDetector's
+          # findPreviousGenerationFromHistory() walks
+          # `git log --first-parent HEAD` — no --no-merges — and takes the FIRST
+          # commit that is authored by fern-api[bot] or whose SUBJECT starts with
+          # `[fern-generated]` / `[fern-replay]`. Merge landing puts the real
+          # generation on the SECOND parent, invisible to that walk, while the
+          # walk still succeeds on an older SQUASHED regeneration further back.
+          # So the anchor freezes and the detection range grows by one commit per
+          # PR forever: measured 2026-08-20, main's anchor was still
+          # `f4a1372 SDK regeneration (#72)`, fourteen first-parent commits back.
+          # Subjecting the merge commit itself puts a current, permanently
+          # reachable anchor on the first-parent chain. Detection is --no-merges,
+          # so the merge commit can never be mistaken for a customization.
+          #
+          # `[fern-replay]`, not `[fern-generated]`, and the distinction is
+          # load-bearing. Both satisfy the detector, but `[fern-generated]` would
+          # also be picked up by AutoVersionStep's own stricter first-parent walk
+          # (`startsWith("[fern-generated]")`), re-anchoring the autoversion
+          # baseline and changing the computed X.Y.Z-dev bump, and by the
+          # `PVe(u) && !KQl(u)` generation scan, which likewise does not pass
+          # --no-merges. `[fern-replay]` is inert to both. Verified against
+          # fern-api 5.100.0's cli.cjs; re-read the applicator after a CLI bump,
+          # because this rides on an undocumented predicate and will fail
+          # silently — a rotting anchor, not an error — if it changes.
+          #
+          # Subject only on the merge path. The squash fallback already matches
+          # the detector through the author clause, and prefixing it would drop
+          # it out of the `!KQl` generation scan it currently appears in.
           if [[ "$(gh api "repos/${REPO}" --jq '.allow_merge_commit')" == "true" ]]; then
             strategy="--merge"
+            subject_args=(-t "[fern-replay] SDK regeneration (#${pr})")
           else
             strategy="--squash"
+            subject_args=()
             echo "::warning::merge commits are disabled on ${REPO}; falling back to --squash. Recorded generation SHAs will be orphaned — see ENG-10280."
           fi
 
@@ -236,13 +268,13 @@ jobs:
           # would often hit.
           if [[ "$(gh pr view "$pr" --repo "$REPO" --json autoMergeRequest --jq '.autoMergeRequest != null')" != "true" ]]; then
             set +e
-            out="$(gh pr merge --auto "$strategy" "$pr" --repo "$REPO" 2>&1)"; rc=$?
+            out="$(gh pr merge --auto "$strategy" ${subject_args[@]+"${subject_args[@]}"} "$pr" --repo "$REPO" 2>&1)"; rc=$?
             set -e
             echo "$out"
             if [[ $rc -ne 0 ]]; then
               if [[ "$out" == *"unstable status"* ]]; then
                 echo "Already fully mergeable; merging directly."
-                gh pr merge "$strategy" "$pr" --repo "$REPO"
+                gh pr merge "$strategy" ${subject_args[@]+"${subject_args[@]}"} "$pr" --repo "$REPO"
               else
                 exit 1
               fi


### PR DESCRIPTION
Mirrors **[hedra-labs/hedra-cli#105](https://github.com/hedra-labs/hedra-cli/pull/105)** — that PR carries the full write-up (why the anchor freezes, why `[fern-replay]` and not `[fern-generated]`, and what was verified against the fern-api CLI). Nothing is re-derived here; read it there.

`.github/workflows/autoland-regen.yml` is duplicated **byte-identically** across [`hedra-cli`](https://github.com/hedra-labs/hedra-cli), [`hedra-python`](https://github.com/hedra-labs/hedra-python) and [`hedra-node`](https://github.com/hedra-labs/hedra-node) — no repo is canonical. `autoland-drift-check.yml` in [`hedra-labs/fern-config`](https://github.com/hedra-labs/fern-config) groups the three copies by sha256 on a daily 06:00 UTC cron and **fails when they disagree**, so this needs to land alongside hedra-cli#105 (a parallel PR does the identical change in `hedra-python`).

## What changed

One block — the one that picks the merge strategy. It adds a `subject_args` bash array, populated on the `--merge` path and left empty on the `--squash` fallback, and threads `${subject_args[@]+"${subject_args[@]}"}` into the two `gh pr merge` call sites. The rest of the diff is the explanatory comment.

## Verification

- `shasum -a 256 .github/workflows/autoland-regen.yml` → `3dcb82e4b9af06f433a307d0c91e55de85a08682b32f72d47ebbb5f7caf12225`, identical to what hedra-cli#105 produces. The three copies stay in sync.
- `actionlint` reports the same two findings before and after — stale `create-github-app-token@v3` metadata, where `client-id` is the correct input and `app-id` is the deprecated one. Pre-existing; deliberately not "fixed" here.
- YAML parses, and `bash -n` is clean on the extracted `run` block.

Refs [ENG-10280](https://linear.app/hedra/issue/ENG-10280/hedra-cli-replays-base-generation-unreachable-warning-is-not-a-shallow).
