### PR TITLE
docs(readme): rewrite the README against the current jobs surface

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,7 +1,9 @@
 # Files Fern must NOT overwrite when it regenerates this SDK (via PR from the
 # hedra-labs/fern-config repo). See https://buildwithfern.com/learn/sdks/capabilities/customize-files
 
-# README install/imports use the @hedra/sdk package name
+# Hand-written. The generated one is Fern's fixed template around the first
+# submit endpoint: a placeholder-prompt submit with no poll, result, streaming
+# frames, or upload wiring, so it would show the SDK's shape, not its use.
 README.md
 
 # Hand-maintained docs / history

--- a/README.md
+++ b/README.md
@@ -3,15 +3,19 @@
 [![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Hedra%2FTypeScript)
 [![npm shield](https://img.shields.io/npm/v/@hedra/sdk)](https://www.npmjs.com/package/@hedra/sdk)
 
-The Hedra TypeScript library provides convenient access to the Hedra APIs from TypeScript.
+The Hedra TypeScript library provides convenient access to the Hedra API v3 from TypeScript and
+JavaScript.
 
 ## Table of Contents
 
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Custom base URL](#custom-base-url)
+- [Resources](#resources)
 - [Request and Response Types](#request-and-response-types)
+- [Streaming](#streaming)
 - [Pagination](#pagination)
 - [Exception Handling](#exception-handling)
 - [File Uploads](#file-uploads)
@@ -22,6 +26,7 @@ The Hedra TypeScript library provides convenient access to the Hedra APIs from T
   - [Timeouts](#timeouts)
   - [Aborting Requests](#aborting-requests)
   - [Access Raw Response Data](#access-raw-response-data)
+  - [Spec Version Header](#spec-version-header)
   - [Logging](#logging)
   - [Custom Fetch](#custom-fetch)
   - [Runtime Compatibility](#runtime-compatibility)
@@ -46,12 +51,12 @@ import { HedraClient } from "@hedra/sdk";
 
 const client = new HedraClient({ apiKey: "YOUR_API_KEY" });
 
-const submitted = await client.jobs.submitKlingO3({
+const submitted = await client.jobs.submitMinimaxH3({
     input: {
         prompt: "a fox sprinting across fresh snow",
         aspect_ratio: "16:9",
-        duration_ms: 5000,
-        quality: "standard",
+        resolution: "768p",
+        duration_ms: 6000,
     },
 });
 
@@ -63,24 +68,66 @@ while (status.status === "IN_QUEUE" || status.status === "IN_PROGRESS") {
 }
 
 const result = await client.jobs.get(submitted.job_id);
-console.log(result.outputs?.[0]?.url);
+for (const output of result.outputs ?? []) {
+    console.log(output.url);
+}
 ```
 
-Every model has its own submit method — `submitKlingO3`, `submitVeo3`, `submitNanoBanana`
-and so on — each taking the `input` that model actually accepts, checked at compile time.
-The [reference](./reference.md) lists all of them.
+Every model has its own submit method — `submitMinimaxH3`, `submitKlingO3`, `submitVeo3`,
+`submitNanoBanana` and so on — each taking the `input` that model actually accepts, checked at
+compile time. The [reference](./reference.md) lists all of them.
 
-Instead of polling you can consume the job's server-sent event stream with
-`client.jobs.stream(job_id)`.
+To run a model by its public id instead, with an untyped `input` that the API validates at submit
+time, use `client.jobs.submit(model, { input })`. This is the call to reach for when the model is
+not known ahead of time, or when a client generated before a model shipped needs to run it:
+
+```typescript
+const submitted = await client.jobs.submit("minimax-h3", {
+    input: {
+        prompt: "a fox sprinting across fresh snow",
+        aspect_ratio: "16:9",
+        resolution: "768p",
+        duration_ms: 6000,
+    },
+});
+```
+
+Every submit body also accepts two optional fields: `webhook`, a URL that receives a signed
+completion webhook, and `idempotency_key`, which replays the original acknowledgement for a
+retried submit instead of enqueueing a duplicate job.
+
+Instead of polling you can follow the job over server-sent events; see [Streaming](#streaming).
+
+## Authentication
 
 The client authenticates with `Authorization: Bearer <api key>`; an API key is the
-`<key_id>:<secret>` credential from the Hedra console. When `apiKey` is not passed,
-it is read from the `HEDRA_API_KEY` environment variable.
+`<key_id>:<secret>` credential from the Hedra console. The API key can also be provided via the
+`HEDRA_API_KEY` environment variable, in which case `apiKey` may be omitted:
+
+```typescript
+import { HedraClient } from "@hedra/sdk";
+
+// Reads HEDRA_API_KEY from the environment
+const client = new HedraClient();
+```
+
+Ephemeral tokens minted with `client.tokens.create(...)` are valid Bearer credentials until they
+expire; pass the returned `token` as `apiKey` to authenticate with one.
+To take over header construction entirely, pass `auth` — either `false` to send no credentials,
+or a function returning the headers to attach:
+
+```typescript
+import { HedraClient } from "@hedra/sdk";
+
+const client = new HedraClient({
+    auth: async () => ({ headers: { Authorization: `Bearer ${await fetchTokenSomehow()}` } }),
+});
+```
 
 ## Custom base URL
 
-The client targets `https://api.hedra.com/v3`. Pass a URL as `environment` to point
-elsewhere (e.g. a mock server in tests):
+The client targets `https://api.hedra.com/v3` (`HedraEnvironment.Production`). Pass a URL as
+`environment` to point elsewhere (e.g. a mock server in tests):
 
 ```typescript
 import { HedraClient } from "@hedra/sdk";
@@ -90,6 +137,32 @@ const client = new HedraClient({
 });
 ```
 
+## Resources
+
+The client exposes one sub-client per API resource:
+
+| Sub-client | What it covers |
+| --- | --- |
+| `client.jobs` | Submit generation jobs (typed per model, or by id), poll status, fetch results, tail logs, stream progress, list history. |
+| `client.models` | Browse the model catalog and each model's input schema, list voices, estimate cost, fetch the OpenAPI document. |
+| `client.files` | Upload media to reference from a submit. |
+| `client.keys` | List, create, rotate and revoke API keys. |
+| `client.tokens` | Mint ephemeral Bearer tokens that expire on a schedule, for clients that should not hold a long-lived key. |
+| `client.billing` | Balance, usage and transaction history. |
+| `client.webhooks` | Manage and test the account's default completion webhook, list and redeliver deliveries, fetch the signing public key. |
+| `client.logDrains` | Manage log drains that batch-forward job logs to an endpoint you own. |
+
+```typescript
+const catalog = await client.models.list({ modality: "video" });
+const detail = await client.models.get("minimax-h3");
+const balance = await client.billing.getBalance();
+```
+
+Each resource is also published as a package subpath — `@hedra/sdk/jobs`, `@hedra/sdk/models`,
+`@hedra/sdk/files`, `@hedra/sdk/keys`, `@hedra/sdk/tokens`, `@hedra/sdk/billing`,
+`@hedra/sdk/webhooks`, `@hedra/sdk/logDrains` — exporting that resource's client class and
+request types on their own.
+
 ## Request and Response Types
 
 The SDK exports all request and response types as TypeScript interfaces. Simply import them with the
@@ -98,15 +171,57 @@ following namespace:
 ```typescript
 import { Hedra } from "@hedra/sdk";
 
-const request: Hedra.SubmitBodyKlingO3 = {
-    ...
+const input: Hedra.InputMinimaxH3 = {
+    prompt: "a fox sprinting across fresh snow",
+    aspect_ratio: "16:9",
+    resolution: "768p",
+    duration_ms: 6000,
 };
+
+const request: Hedra.SubmitBodyMinimaxH3 = { input };
+```
+
+Enum-valued fields are exported as `as const` objects alongside their types, so
+`Hedra.InputMinimaxH3.Resolution.SevenHundredSixtyEightP` and the literal `"768p"` are
+interchangeable. Response envelopes are typed the same way: `Hedra.SubmitResponse`,
+`Hedra.StatusResponse`, `Hedra.ResultResponse`, `Hedra.OutputItem`, and `Hedra.JobStatus`
+(`"IN_QUEUE" | "IN_PROGRESS" | "COMPLETED" | "FAILED"`).
+
+## Streaming
+
+`client.jobs.stream(job_id)` follows a job over server-sent events instead of polling. It resolves
+to an async iterable that yields a `StatusResponse` for every `status` frame and a `JobLogItem` for
+every `log` frame, and ends once the job reaches a terminal state:
+
+```typescript
+// submitted is the SubmitResponse returned by any submit call
+const stream = await client.jobs.stream(submitted.job_id);
+for await (const event of stream) {
+    if ("status" in event) {
+        console.log(event.status, event.progress);
+    } else {
+        console.log(event.level, event.message);
+    }
+}
+```
+
+A dropped connection is resumed automatically from the last event id. Tune that with the `stream`
+option, on the client or per request:
+
+```typescript
+const client = new HedraClient({
+    stream: { reconnectionEnabled: true, maxReconnectionAttempts: 5 },
+});
+
+const stream = await client.jobs.stream(submitted.job_id, {}, {
+    stream: { reconnectionEnabled: false },
+});
 ```
 
 ## Pagination
 
-`client.jobs.list(...)` returns a `Page` that can be iterated asynchronously; it
-fetches cursor pages lazily as you iterate:
+Paginated requests return a `Page` that can be iterated asynchronously; it fetches cursor pages
+lazily as you iterate:
 
 ```typescript
 const page = await client.jobs.list({ limit: 50 });
@@ -115,21 +230,43 @@ for await (const job of page) {
 }
 ```
 
-## Exception Handling
-
-When the API returns a non-success status code (4xx or 5xx response), a subclass of the following error
-will be thrown.
+You can also iterate page by page and access the typed response for each one:
 
 ```typescript
-import { HedraError } from "@hedra/sdk";
+let page = await client.jobs.list({ limit: 50 });
+while (true) {
+    console.log(page.response); // the typed JobListResponse for this page
+    for (const job of page.data) {
+        console.log(job.job_id);
+    }
+    if (!page.hasNextPage()) break;
+    page = await page.getNextPage();
+}
+```
+
+## Exception Handling
+
+When the API returns a non-success status code (4xx or 5xx response), a subclass of `HedraError` is
+thrown. Each documented status has its own class under the `Hedra` namespace — `BadRequestError`,
+`UnauthorizedError`, `PaymentRequiredError`, `ForbiddenError`, `NotFoundError`,
+`UnprocessableEntityError`, `TooManyRequestsError` and `InternalServerError` — with a typed
+`body`. A request that exceeds its timeout throws `HedraTimeoutError`.
+
+```typescript
+import { Hedra, HedraError, HedraTimeoutError } from "@hedra/sdk";
 
 try {
-    await client.jobs.submitKlingO3(...);
+    await client.jobs.get("job_does_not_exist");
 } catch (err) {
-    if (err instanceof HedraError) {
+    if (err instanceof Hedra.NotFoundError) {
+        console.log(err.body); // typed Hedra.ErrorResponse
+    } else if (err instanceof HedraTimeoutError) {
+        console.log("timed out", err.cause);
+    } else if (err instanceof HedraError) {
         console.log(err.statusCode);
         console.log(err.message);
         console.log(err.body);
+        console.log(err.requestId); // the response's x-request-id, if any
         console.log(err.rawResponse);
     }
 }
@@ -137,17 +274,33 @@ try {
 
 ## File Uploads
 
-You can upload files using the client:
+Media inputs (`start_image`, `end_image`, `images`, `audio`, `video`, …) take either a public URL or
+a file you uploaded first. `client.files.upload` stores the bytes and returns a presigned URL that is
+the file's handle for the next hour; pass it back verbatim as a `url` source:
 
 ```typescript
 import * as fs from "fs";
 import { HedraClient } from "@hedra/sdk";
 
 const client = new HedraClient({ apiKey: "YOUR_API_KEY" });
-await client.files.upload({
-    file: fs.createReadStream("/path/to/your/file"),
+
+const upload = await client.files.upload({
+    file: fs.createReadStream("frame.png"),
+});
+
+await client.jobs.submitMinimaxH3({
+    input: {
+        prompt: "the fox turns toward the camera",
+        resolution: "768p",
+        duration_ms: 6000,
+        start_image: { source: "url", url: upload.url },
+    },
 });
 ```
+
+A completed job's outputs carry an `asset_id`; pass `{ source: "asset", asset_id }` instead of a
+URL to reuse an output as the input to a later job.
+
 The client accepts a variety of types for file upload parameters:
 * Stream types: `fs.ReadStream`, `stream.Readable`, and `ReadableStream`
 * Buffered types: `Buffer`, `Blob`, `File`, `ArrayBuffer`, `ArrayBufferView`, and `Uint8Array`
@@ -199,7 +352,7 @@ const client = new HedraClient({
     }
 });
 
-const response = await client.jobs.submitKlingO3(..., {
+const response = await client.jobs.submitMinimaxH3(..., {
     headers: {
         'X-Custom-Header': 'custom value'
     }
@@ -211,7 +364,7 @@ const response = await client.jobs.submitKlingO3(..., {
 If you would like to send additional query string parameters as part of the request, use the `queryParams` request option.
 
 ```typescript
-const response = await client.jobs.submitKlingO3(..., {
+const response = await client.jobs.submitMinimaxH3(..., {
     queryParams: {
         'customQueryParamKey': 'custom query param value'
     }
@@ -222,26 +375,17 @@ const response = await client.jobs.submitKlingO3(..., {
 
 The SDK is instrumented with automatic retries with exponential backoff. A request will be retried as long
 as the request is deemed retryable and the number of retry attempts has not grown larger than the configured
-retry limit (default: 2).
+retry limit (default: 2). A response is retryable when its status is:
 
-Which status codes are retried depends on the `retryStatusCodes` generator configuration:
-
-**`legacy`** (current default): retries on
 - [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
 - [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
 - [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#server_error_responses) (All server errors, including 500)
 
-**`recommended`**: retries on
-- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
-- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
-- [502](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502) (Bad Gateway)
-- [503](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503) (Service Unavailable)
-- [504](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) (Gateway Timeout)
-
-Use the `maxRetries` request option to configure this behavior.
+A `Retry-After` header is honoured when the server sends one. Use the `maxRetries` option, on the
+client or per request, to configure this behavior.
 
 ```typescript
-const response = await client.jobs.submitKlingO3(..., {
+const response = await client.jobs.submitMinimaxH3(..., {
     maxRetries: 0 // override maxRetries at the request level
 });
 ```
@@ -251,7 +395,7 @@ const response = await client.jobs.submitKlingO3(..., {
 The SDK defaults to a 60 second timeout. Use the `timeoutInSeconds` option to configure this behavior.
 
 ```typescript
-const response = await client.jobs.submitKlingO3(..., {
+const response = await client.jobs.submitMinimaxH3(..., {
     timeoutInSeconds: 30 // override timeout to 30s
 });
 ```
@@ -262,7 +406,7 @@ The SDK allows users to abort requests at any point by passing in an abort signa
 
 ```typescript
 const controller = new AbortController();
-const response = await client.jobs.submitKlingO3(..., {
+const response = await client.jobs.submitMinimaxH3(..., {
     abortSignal: controller.signal
 });
 controller.abort(); // aborts the request
@@ -274,11 +418,18 @@ The SDK provides access to raw response data, including headers, through the `.w
 The `.withRawResponse()` method returns a promise that results to an object with a `data` and a `rawResponse` property.
 
 ```typescript
-const { data, rawResponse } = await client.jobs.submitKlingO3(...).withRawResponse();
+const { data, rawResponse } = await client.jobs.submitMinimaxH3(...).withRawResponse();
 
 console.log(data);
-console.log(rawResponse.headers['X-My-Header']);
+console.log(rawResponse.headers.get("x-request-id"));
 ```
+
+### Spec Version Header
+
+Every request carries an `X-Hedra-Spec-Version` header naming the OpenAPI spec version this client
+was generated from, so the server can tell which generation of the API a caller was built against.
+It is sent automatically; the `specVersion` option that backs it is typed to the pinned version, so
+there is nothing to configure.
 
 ### Logging
 
@@ -382,10 +533,7 @@ other than your configured base.
 
 ### Runtime Compatibility
 
-
 The SDK works in the following runtimes:
-
-
 
 - Node.js 18+
 - Vercel
@@ -393,7 +541,6 @@ The SDK works in the following runtimes:
 - Deno v1.25+
 - Bun 1.0+
 - React Native
-
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hedra/sdk",
-    "version": "5.0.0",
+    "version": "5.0.1-dev",
     "private": false,
     "repository": {
         "type": "git",


### PR DESCRIPTION
The README is hand-maintained (`.fernignore`d since the Stainless→Fern migration), and it had drifted from the SDK it ships with: it showed only `client.jobs` and `client.files`, never mentioned streaming beyond one sentence, the untyped `client.jobs.submit(model, …)` escape hatch, the other six sub-clients, the subpath exports, the typed error classes, or how an uploaded file is actually wired into a submit. One template snippet did not compile under strict TypeScript.

This rewrites it against the current code, mirroring the structure of the Python SDK's README ([hedra-labs/hedra-python](https://github.com/hedra-labs/hedra-python)) so the two SDKs read the same way.

## What changed

- **Usage** — quickstart now uses `submitMinimaxH3` (the same model and inputs as the Python quickstart), keeps the poll loop, and iterates `outputs`. Adds the untyped `client.jobs.submit(model, { input })` call and the `webhook` / `idempotency_key` fields every submit body takes.
- **Authentication** — new section: `HEDRA_API_KEY` fallback shown as code, ephemeral tokens from `client.tokens.create`, and the `auth` override (`false`, or a function returning headers).
- **Resources** — new table covering all eight sub-clients (`jobs`, `models`, `files`, `keys`, `tokens`, `billing`, `webhooks`, `logDrains`) and the `@hedra/sdk/<resource>` subpath exports package.json publishes.
- **Streaming** — new section: `client.jobs.stream` yields `StatusResponse` / `JobLogItem` frames, ends on the terminal frame, resumes from the last event id, and takes `stream: { reconnectionEnabled, maxReconnectionAttempts }` on the client or per request.
- **Pagination** — adds the page-by-page form (`page.data`, `page.response`, `hasNextPage()`, `getNextPage()`).
- **Exception Handling** — names the typed subclasses under `Hedra.*`, `HedraTimeoutError`, and `err.requestId`.
- **File Uploads** — shows the upload wired into a submit as `{ source: "url", url: upload.url }`, the one-hour handle lifetime, and `{ source: "asset", asset_id }` reuse of an output.
- **Retries** — describes what the shipped code does (408 / 429 / 5xx, `Retry-After` honoured) instead of the generator's `legacy` vs `recommended` knob, which no SDK user can flip.
- **Access Raw Response Data** — `rawResponse.headers['X-My-Header']` → `rawResponse.headers.get(...)`. `headers` is a Fetch `Headers`; the bracket form is `TS7052` under `strict`.
- **Spec Version Header** — new note on `X-Hedra-Spec-Version` / `specVersion`.
- `.fernignore` — the comment on the `README.md` entry now says why the file is hand-owned.

## Why not let Fern generate it

Checked against the generator itself, so this stays a deliberate choice. `fernapi/fern-typescript-sdk` 3.88.3 does render a `README.md` inside its container (the CLI's local output modes just never copy it out; it was retrieved with `docker cp` from a kept container). What it produces is the stock template around the first submit endpoint, in full:

- **Usage** is `client.jobs.submitDreamina31({ input: { prompt: "prompt", aspect_ratio: "16:9", resolution: "540p" } })` — a placeholder prompt, no poll loop, no result fetch, nothing about the other ninety-odd submit methods or the untyped `submit(model, …)`.
- **Streaming Response** is a generic `for await (const item of response)` with no word on what the frames are or when the stream ends.
- No authentication section at all: `HEDRA_API_KEY`, the `<key_id>:<secret>` format, tokens and the `auth` override are absent.
- **File Uploads** is the bare upload call, never wired into a submit, and its `Uploadable` snippets are missing their import.
- **Access Raw Response Data** has the same `rawResponse.headers['X-My-Header']` snippet, which does not compile under `strict` (`TS7052`).
- **Pagination**'s page-by-page loop is `page = page.getNextPage()` with no `await`, which is a type error (`getNextPage()` returns a `Promise`). The same snippet is in the generated `reference.md`.
- **Retries** documents a generator-side `legacy` / `recommended` knob that no SDK user can change.

The one thing the template covers that the hand-written README did not was the subpath exports; this rewrite adds them. Hand-owning the README is the right call; this PR makes the hand-owned copy true.

## Verification

- Every code snippet in the new README was transcribed into one `.ts` file and type-checked against `src/` with the repo's own TypeScript (`strict`, exit 0). The old README's snippets were checked the same way, which is how the `headers[...]` defect surfaced.
- Prose claims were checked against the code: `BearerAuthProvider` (Bearer + `HEDRA_API_KEY`), `requestWithRetries.ts` (codes, default 2, `Retry-After`), the 60 s default in every resource client, `logger.ts` defaults, `makePassthroughRequest.ts` (no production fallback, auth only against the base origin), `Stream.ts` (reconnection defaults), `package.json` `exports`.
- No source changed; `pnpm check` scope (hand-maintained JS/TS) is unaffected.

Second commit: `package.json` goes from `5.0.0` to `5.0.1-dev`, the next patch dev version. `package.json` is the version's source of truth; the next regeneration stamps `src/version.ts` and the SDK headers from it, so nothing else is hand-edited, matching the previous manual version change.

Not touched here: `CHANGELOG.md` is also `.fernignore`d and still stops at 0.3.0 describing `client.queue` / `client.requests`, which no longer exist. Separate PR.
